### PR TITLE
Avoid Hard-Coding Stop Words (used NLTK Corpus Instead)

### DIFF
--- a/src/python/txtai/tokenizer.py
+++ b/src/python/txtai/tokenizer.py
@@ -4,16 +4,18 @@ Text tokenization methods
 
 import re
 import string
+import nltk
+from nltk.corpus import stopwords
+nltk.download('stopwords')
+
 
 class Tokenizer(object):
     """
     Text tokenization methods
     """
 
-    # English Stop Word List (Standard stop words used by Apache Lucene)
-    STOP_WORDS = {"a", "an", "and", "are", "as", "at", "be", "but", "by", "for", "if", "in", "into", "is", "it",
-                  "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there", "these",
-                  "they", "this", "to", "was", "will", "with"}
+    # English Stop Word List (Standard stop words by NLTK Corpus)
+    STOP_WORDS = stopwords.words('english')
 
     @staticmethod
     def tokenize(text):


### PR DESCRIPTION
Previously, the `STOP_WORDS` in  `tokenizer.py` were hardcoded, which may not be the best approach. So instead, the NLTK corpus provides a wider array of stopwords that could provide better pre-processing results.