### PR TITLE
Update 03_Build_an_Embeddings_index_from_a_data_source.ipynb

### DIFF
--- a/examples/03_Build_an_Embeddings_index_from_a_data_source.ipynb
+++ b/examples/03_Build_an_Embeddings_index_from_a_data_source.ipynb
@@ -314,6 +314,14 @@
         "df = pd.DataFrame(results, columns=[\"Title\", \"Published\", \"Reference\", \"Match\"])\n",
         "\n",
         "display(HTML(df.to_html(index=False)))"
+        #If this python script is run in vscode environment, the above line of code will not display the results.
+        #One option is to save the results in a local file data.html, and use the browser to open it to view the result.
+        #This method can be applied to all the other occurences of "display(HTML(df.to_html(index=False)))" in the rest of the example codes.
+        #Uncomment the following 4 lines of code if this is your situation:
+        #htmlData = df.to_html(index=False)
+        #with open("data.html", "w") as file:
+        #    file.write(htmlData)
+        #print("done writing result to data.html.")
       ],
       "execution_count": 5,
       "outputs": [


### PR DESCRIPTION
display(HTML(df.to_html(index=False))) works in a browser development environment, but will display a message like this "<IPython.core.display.HTML object>" in a local environment. Added suggestions to those who run the script in vscode or local command line environment. Instead of displaying the result to a browser, write the html result into a local file, and then use the browser to open the html file to view the result.