### PR TITLE
Update 04_Extractive_QA_with_Elasticsearch.ipynb

### DIFF
--- a/examples/04_Extractive_QA_with_Elasticsearch.ipynb
+++ b/examples/04_Extractive_QA_with_Elasticsearch.ipynb
@@ -75,6 +75,8 @@
       "execution_count": 2,
       "outputs": []
     },
+    Note: if this is tested in a vscode or local developmeent environment, one can go to elasticsearch-7.8.1/bin directory, 
+    directly start the elasticsearch server by typing "./elasticsearch" in the command line.
     {
       "cell_type": "markdown",
       "metadata": {


### PR DESCRIPTION
In vscode or local dev environment, the original code will not start the elastic search server. By launching the elastic search server in a separate command line window, the rest of the script is able to connect the elastic search server and continues successfully.