### PR TITLE
Fix incorrect import in Notebooks

### DIFF
--- a/examples/03_Build_an_Embeddings_index_from_a_data_source.ipynb
+++ b/examples/03_Build_an_Embeddings_index_from_a_data_source.ipynb
@@ -373,7 +373,7 @@
       },
       "source": [
         "%%capture\n",
-        "from txtai.extractor import Extractor\n",
+        "from txtai.pipeline import Extractor\n",
         "\n",
         "# Create extractor instance using qa model designed for the CORD-19 dataset\n",
         "extractor = Extractor(embeddings, \"NeuML/bert-small-cord19qa\")"

--- a/examples/05_Extractive_QA_with_txtai.ipynb
+++ b/examples/05_Extractive_QA_with_txtai.ipynb
@@ -71,7 +71,7 @@
         "%%capture\n",
         "\n",
         "from txtai.embeddings import Embeddings\n",
-        "from txtai.extractor import Extractor\n",
+        "from txtai.pipeline import Extractor\n",
         "\n",
         "# Create embeddings model, backed by sentence-transformers & transformers\n",
         "embeddings = Embeddings({\"path\": \"sentence-transformers/nli-mpnet-base-v2\"})\n",

--- a/examples/06_Extractive_QA_with_Elasticsearch.ipynb
+++ b/examples/06_Extractive_QA_with_Elasticsearch.ipynb
@@ -313,7 +313,7 @@
       "source": [
         "%%capture\n",
         "from txtai.embeddings import Embeddings\n",
-        "from txtai.extractor import Extractor\n",
+        "from txtai.pipeline import Extractor\n",
         "\n",
         "# Create embeddings model, backed by sentence-transformers & transformers\n",
         "embeddings = Embeddings({\"path\": \"sentence-transformers/nli-mpnet-base-v2\"})\n",


### PR DESCRIPTION
This fixes `ModuleNotFoundError: No module named 'txtai.extractor'` in the Notebooks