### PR TITLE
Support for Qdrant as an embedding backend

### DIFF
--- a/examples/similarity_api_with_qdrant/config.yml
+++ b/examples/similarity_api_with_qdrant/config.yml
@@ -1,0 +1,17 @@
+# Index file path
+path: /tmp/index
+
+# Allow indexing of documents
+writable: True
+
+# Embeddings index
+embeddings:
+  path: sentence-transformers/all-MiniLM-L6-v2
+  backend: qdrant
+  qdrant:
+    collection_name: Example
+    connection:
+      host: localhost
+    collection:
+      hnsw_config:
+        ef_construct: 150

--- a/examples/similarity_api_with_qdrant/readme.md
+++ b/examples/similarity_api_with_qdrant/readme.md
@@ -1,0 +1,37 @@
+# Running txtai with Qdrant backend
+
+Qdrant - is fast and scalable vector search engine, which CRUD API along with similarity search API.
+
+Qdrant can replace FAISS/Annoy/HNSWLIB indexes in production environment, which requires high availability, high throughput and flexibility.
+
+
+## Run Qdrant
+
+```
+docker run -p 6333:6333 qdrant/qdrant
+```
+
+More info on [Qdrant](https://github.com/qdrant/qdrant).
+
+## Configuration
+
+```yaml
+# Embeddings index
+embeddings:
+  path: sentence-transformers/all-MiniLM-L6-v2
+  backend: qdrant
+  qdrant:
+    collection_name: Example  # Collection name used in Qdrant
+    connection:
+      host: localhost # Host of the qdrant service
+    collection:
+      hnsw_config:
+        ef_construct: 150
+```
+
+With this configuration, Qdrant will be used as a backend for embeddings index.
+
+To run example:
+```
+CONFIG=examples/similarity_api_with_qdrant/config.yml uvicorn "txtai.api:app"
+```

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,8 @@ extras["similarity"] = [
     "sentence-transformers>=2.2.0",
 ]
 
+extras["qdrant"] = ["qdrant-client>=0.9.5"]
+
 extras["workflow"] = [
     "apache-libcloud>=3.3.1",
     "croniter>=1.2.0",

--- a/src/python/txtai/ann/factory.py
+++ b/src/python/txtai/ann/factory.py
@@ -5,6 +5,7 @@ Factory module
 from .annoy import Annoy, ANNOY
 from .faiss import Faiss
 from .hnsw import HNSW, HNSWLIB
+from .qdrant import Qdrant, QDRANT
 
 
 class ANNFactory:
@@ -39,6 +40,10 @@ class ANNFactory:
                 raise ImportError('hnswlib library is not available - install "similarity" extra to enable')
 
             model = HNSW(config)
+        elif backend == "qdrant":
+            if not QDRANT:
+                raise ImportError('qdrant-client library is not available - install "qdrant" extra to enable')
+            model = Qdrant(config)
         else:
             model = Faiss(config)
 

--- a/src/python/txtai/ann/qdrant.py
+++ b/src/python/txtai/ann/qdrant.py
@@ -1,0 +1,91 @@
+"""
+Qdrant module
+"""
+
+# Conditional import
+try:
+    # pylint: disable=E0611
+    from qdrant_client import QdrantClient
+    from qdrant_client.http.models.models import Distance, PointIdsList
+
+    QDRANT = True
+except ImportError:
+    QDRANT = False
+
+from .base import ANN
+
+DEFAULT_COLLECTION_NAME = "embeddings"
+
+
+class Qdrant(ANN):
+    distance_mapping = {
+        "ip": Distance.DOT,
+        "l2": Distance.EUCLID,
+        "cosine": Distance.COSINE,
+    }
+
+    @property
+    def _collection_name(self):
+        return self.config.get("qdrant", {}).get("collection_name", DEFAULT_COLLECTION_NAME)
+
+    @property
+    def _distance(self):
+        return self.distance_mapping.get(self.config.get("metric"), Distance.COSINE)
+
+    def _connect(self):
+        self.model = QdrantClient(
+            **self.config.get("qdrant", {}).get("connection", {})
+        )
+
+    def load(self, _path):
+        self._connect()
+
+    def index(self, embeddings):
+        self._connect()
+        self.model.recreate_collection(
+            collection_name=self._collection_name,
+            vector_size=self.config["dimensions"],
+            distance=self._distance,
+            **self.config.get("qdrant", {}).get("collection", {})
+        )
+        self.model.upload_collection(
+            collection_name=self._collection_name,
+            vectors=embeddings,
+            **self.config.get("qdrant", {}).get("upload", {})
+        )
+
+        self.config["offset"] = embeddings.shape[0]
+
+    def append(self, embeddings):
+        new = embeddings.shape[0]
+        self.model.upload_collection(
+            collection_name=self._collection_name,
+            vectors=embeddings,
+            ids=range(self.config["offset"], self.config["offset"] + new)
+        )
+
+        self.config["offset"] += new
+
+    def delete(self, ids):
+        self.model.delete(
+            collection_name=self._collection_name,
+            points_selector=PointIdsList(points=ids),
+        )
+
+    def search(self, queries, limit):
+        results = []
+        for query in queries:
+            hits = self.model.search(
+                collection_name=self._collection_name,
+                query_vector=query.tolist(),
+                search_params=self.config.get("qdrant", {}).get("search_params", {}),
+                limit=limit,
+            )
+            results.append([(hit.id, hit.score) for hit in hits])
+        return results
+
+    def count(self):
+        return self.model.count(collection_name=self._collection_name).count
+
+    def save(self, _path):
+        pass

--- a/src/python/txtai/embeddings/base.py
+++ b/src/python/txtai/embeddings/base.py
@@ -418,6 +418,7 @@ class Embeddings:
             if self.config.get("storevectors"):
                 self.config["path"] = os.path.join(path, self.config["path"])
 
+
         # Approximate nearest neighbor index - stores embeddings vectors
         self.ann = ANNFactory.create(self.config)
         self.ann.load(f"{path}/embeddings")


### PR DESCRIPTION
Hi @davidmezzetti, thanks a lot for a great project!

But I believe it could be even better with proper vector search engine under the hood :wink: 
I also believe that Qdrant is the best choice for that.

Here are some of the potential benefits it could bring:

- eliminate the need for explicit index rebuilding - Qdrant manages the vector storage in a way, that no matter updates or indexation - it always available for writes and searches.
- Scale more easily, decouple storage and encoders - it usually requires very different machines to serve encoding and search, so qdrant integration will solve that.
- possibility to make txtai stateless - I have noticed, that txtai uses `path: /tmp/index` for storing index and configuration, that could be a potential problem in case of e.g. k8s deployment, volume management could become too complicated. With dedicated storage backend it could be possible to place the whole state of the application into there.

This PR is an example of how Qdrant can potentially work with txtai, there are still some rough spots, e.g. saving offsets into the configuration: `self.config["offset"] += new`.

Would love to hear your thoughts,
Thanks!
