### PR TITLE
Fix docker command "--it"

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -16,7 +16,7 @@ The base txtai images have no models installed and models will be downloaded eac
 - Create a container with the [models cached](#container-image-model-caching)
 - Set the transformers cache environment variable and mount that volume when starting the image
     ```bash
-    docker run -v <local dir>:/models -e TRANSFORMERS_CACHE=/models --rm --it <docker image>
+    docker run -v <local dir>:/models -e TRANSFORMERS_CACHE=/models --rm -it <docker image>
     ```
 
 ## Build txtai images


### PR DESCRIPTION
Hi David,

I ran into this while I was playing with txtai.

The current command generates

```
unknown flag: --it
See 'docker run --help'
```
when executing on Linux.
