### PR TITLE
update syntax for ES 8.x

### DIFF
--- a/examples/04_Add_semantic_search_to_Elasticsearch.ipynb
+++ b/examples/04_Add_semantic_search_to_Elasticsearch.ipynb
@@ -197,11 +197,9 @@
         "    display(HTML(html))\n",
         "\n",
         "def search(query, limit):\n",
+        "  size = limit
         "  query = {\n",
-        "      \"size\": limit,\n",
-        "      \"query\": {\n",
-        "          \"query_string\": {\"query\": query}\n",
-        "      }\n",
+        "   \"query_string\": {\"query\": query}\n",        "      
         "  }\n",
         "\n",
         "  results = []\n",


### PR DESCRIPTION
ES 8.x deprecated the `body` parameter, in favour of passing parameters directly to the query. I'm not sure if this will work retroactively with ES 7.x, but the python elasticsearch that is installed in this Example is for the most recent version (8.4.2 as of now).