### PR TITLE
Modified logger configuration in __init__.py (libraries shouldn't modify root logger)

### DIFF
--- a/src/python/txtai/__init__.py
+++ b/src/python/txtai/__init__.py
@@ -4,8 +4,13 @@ Version string
 
 import logging
 
-# Set default logging format
-logging.basicConfig(format="%(asctime)s [%(levelname)s] %(funcName)s: %(message)s")
+# Configure logging for the txtai package
+# We should use logging.basicConfig() here as it modifies the root logger.  But
+# log handlers/formatters should only be tweaked in the application code.  Ref:
+#   - https://stackoverflow.com/a/27017068/19357935
+#   - https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 # Current version tag
 __version__ = "5.2.0"

--- a/src/python/txtai/__init__.py
+++ b/src/python/txtai/__init__.py
@@ -4,11 +4,7 @@ Version string
 
 import logging
 
-# Configure logging for the txtai package
-# We should use logging.basicConfig() here as it modifies the root logger.  But
-# log handlers/formatters should only be tweaked in the application code.  Ref:
-#   - https://stackoverflow.com/a/27017068/19357935
-#   - https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+# Configure logging per standard Python library recommendations
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 


### PR DESCRIPTION
Very minor tweak suggested to`__init__.py` only.

I've been getting duplicate log messages when I import `txtai` into my code.  It turns out txtai modifies Python's root logger in it's `__init__.py` using `logging.basicConfig()`.  However it is recommended that "importable" libraries do not configure log handlers/formatters, and that they should leave that to the "application" code.

So I've edited this line to better reflect the recommendations from the [official python docs](https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library).