### PR TITLE
Added cls pooling for onnx conversion

### DIFF
--- a/src/python/txtai/models/__init__.py
+++ b/src/python/txtai/models/__init__.py
@@ -4,6 +4,6 @@ Models imports
 
 from .models import Models
 from .onnx import OnnxModel
-from .pooling import MeanPooling, Pooling
+from .pooling import MeanPooling, Pooling, CLSPooling
 from .registry import Registry
 from .tokendetection import TokenDetection

--- a/src/python/txtai/models/pooling.py
+++ b/src/python/txtai/models/pooling.py
@@ -130,3 +130,26 @@ class MeanPooling(Pooling):
         # pylint: disable=E1101
         mask = mask.unsqueeze(-1).expand(tokens.size()).float()
         return torch.sum(tokens * mask, 1) / torch.clamp(mask.sum(1), min=1e-9)
+
+
+class CLSPooling(Pooling):
+    """
+    Builds mean pooled vectors usings outputs from a transformers model.
+    """
+
+    def forward(self, **inputs):
+        """
+        Runs mean pooling on token embeddings taking the input mask into account.
+
+        Args:
+            inputs: model inputs
+
+        Returns:
+            mean pooled embeddings using output token embeddings (i.e. last hidden state)
+        """
+
+        # Run through transformers model
+        tokens = super().forward(**inputs)
+        # CLS pooling
+        # pylint: disable=E1101
+        return tokens[:, 0]


### PR DESCRIPTION
Some models use not the mean pooling but other types of pooling. One of them is CLS-Pooling from Sentence Transformers.
For example, the current state-of-the-art model on the MTEB Leaderboard uses it (BAAI/bge-large-en).


https://huggingface.co/BAAI/bge-large-en/blob/main/1_Pooling/config.json

The code is mostly copy-pasted from the Sentence Transformers library.