### PR TITLE
Added int32 conversion for inputs

### DIFF
--- a/src/python/txtai/pipeline/train/hfonnx.py
+++ b/src/python/txtai/pipeline/train/hfonnx.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     ONNX_RUNTIME = False
 
+from torch import Tensor
 from torch.onnx import export
 
 from transformers import AutoModel, AutoModelForQuestionAnswering, AutoModelForSequenceClassification, AutoTokenizer
@@ -54,7 +55,7 @@ class HFOnnx(Tensors):
 
         # Generate dummy inputs
         dummy = dict(tokenizer(["test inputs"], return_tensors="pt"))
-
+        dummy = {k: Tensor.int(v) for k, v in dummy.items()}
         # Default to BytesIO if no output file provided
         output = output if output else BytesIO()
 


### PR DESCRIPTION
For some reason, onnx converted my inputs to int64.
To resolve this issues, I tried preventively converting the dummy inputs to int32.