### PR TITLE
Update 19_Train_a_QA_model.ipynb

### DIFF
--- a/examples/19_Train_a_QA_model.ipynb
+++ b/examples/19_Train_a_QA_model.ipynb
@@ -47,6 +47,7 @@
       },
       "source": [
         "%%capture\n",
+        "!pip install -qU accelerate",
         "!pip install git+https://github.com/neuml/txtai datasets pandas"
       ],
       "execution_count": null,

--- a/examples/19_Train_a_QA_model.ipynb
+++ b/examples/19_Train_a_QA_model.ipynb
@@ -47,7 +47,7 @@
       },
       "source": [
         "%%capture\n",
-        "!pip install git+https://github.com/neuml/txtai datasets pandas accelerate"
+        "!pip install git+https://github.com/neuml/txtai datasets pandas ibis-framework>=7.2 accelerate>=0.20.1"
       ],
       "execution_count": null,
       "outputs": []

--- a/examples/19_Train_a_QA_model.ipynb
+++ b/examples/19_Train_a_QA_model.ipynb
@@ -47,8 +47,7 @@
       },
       "source": [
         "%%capture\n",
-        "!pip install -qU accelerate",
-        "!pip install git+https://github.com/neuml/txtai datasets pandas"
+        "!pip install git+https://github.com/neuml/txtai datasets pandas accelerate"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Colab has an outdated version of accelerate and the suggestion from Colab didn't work.

!pip install -qU accelerate

makes everything work out of the box again

personal note: 
using %%capture can be confusing for newbies such as myself. !pip install -q .... feels a bit more visual while avoiding the bulk of the install.