### PR TITLE
A bug in latest litellm.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras["pipeline-data"] = ["beautifulsoup4>=4.9.3", "nltk>=3.5", "pandas>=1.1.0"
 
 extras["pipeline-image"] = ["imagehash>=4.2.1", "pillow>=7.1.2", "timm>=0.4.12"]
 
-extras["pipeline-llm"] = ["litellm>=1.15.8", "llama-cpp-python>=0.2.20"]
+extras["pipeline-llm"] = ["litellm==1.28.11", "llama-cpp-python>=0.2.20"]
 
 extras["pipeline-text"] = ["fasttext>=0.9.2", "sentencepiece>=0.1.91"]
 


### PR DESCRIPTION
A small fix for you. The latest `litellm` has at least one bug in it. Specifically version: 1.28.13 seems to fail with:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.8/dist-packages/txtai/__init__.py", line 8, in <module>
    from .app import Application
  File "/usr/local/lib/python3.8/dist-packages/txtai/app/__init__.py", line 5, in <module>
    from .base import Application, ReadOnlyError
  File "/usr/local/lib/python3.8/dist-packages/txtai/app/base.py", line 12, in <module>
    from ..embeddings import Documents, Embeddings
  File "/usr/local/lib/python3.8/dist-packages/txtai/embeddings/__init__.py", line 5, in <module>
    from .base import Embeddings
  File "/usr/local/lib/python3.8/dist-packages/txtai/embeddings/base.py", line 17, in <module>
    from ..graph import GraphFactory
  File "/usr/local/lib/python3.8/dist-packages/txtai/graph/__init__.py", line 5, in <module>
    from .base import Graph
  File "/usr/local/lib/python3.8/dist-packages/txtai/graph/base.py", line 14, in <module>
    from .topics import Topics
  File "/usr/local/lib/python3.8/dist-packages/txtai/graph/topics.py", line 5, in <module>
    from ..pipeline import Tokenizer
  File "/usr/local/lib/python3.8/dist-packages/txtai/pipeline/__init__.py", line 12, in <module>
    from .llm import *
  File "/usr/local/lib/python3.8/dist-packages/txtai/pipeline/llm/__init__.py", line 5, in <module>
    from .factory import GenerationFactory
  File "/usr/local/lib/python3.8/dist-packages/txtai/pipeline/llm/factory.py", line 8, in <module>
    from .litellm import LiteLLM
  File "/usr/local/lib/python3.8/dist-packages/txtai/pipeline/llm/litellm.py", line 7, in <module>
    import litellm as api
  File "/usr/local/lib/python3.8/dist-packages/litellm/__init__.py", line 590, in <module>
    from .llms.bedrock import (
  File "/usr/local/lib/python3.8/dist-packages/litellm/llms/bedrock.py", line 285, in <module>
    class AmazonMistralConfig:
  File "/usr/local/lib/python3.8/dist-packages/litellm/llms/bedrock.py", line 301, in AmazonMistralConfig
    stop: Optional[list[str]] = None
```

You might want to consider locking down these dependencies a bit more to avoid these issues? I don't typically use `setup.py`, so I am unsure what the best method is for doing so when you are using `setup.py`, but I've had a lot of success with [pip-tools](https://github.com/jazzband/pip-tools) for doing this at work. Specifically this set of commands:
```
python -m piptools compile cloudfunction/dev-requirements.in
python -m piptools compile cloudfunction/requirements.in
python -m piptools sync cloudfunction/dev-requirements.txt cloudfunction/requirements.txt
```