### PR TITLE
feat: Qdrant ANN backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,16 @@ jobs:
         run: choco install wget
         if: matrix.os == 'windows-latest'
 
+      - name: Run Qdrant
+        run: |
+          docker run -d --rm --network=host qdrant/qdrant:v1.9.0
+          until curl --silent --fail http://localhost:6333/readyz; do
+          echo "Waiting for Qdrant server"
+          sleep 5
+          done
+          echo "\nQdrant server started!"
+        if: matrix.os == 'ubuntu-latest'
+
       - name: Build
         run: |
           pip install -U wheel

--- a/docs/embeddings/configuration/ann.md
+++ b/docs/embeddings/configuration/ann.md
@@ -3,17 +3,19 @@
 The following covers the available vector index configuration options.
 
 ## backend
+
 ```yaml
-backend: faiss|hnsw|annoy|numpy|torch|custom
+backend: faiss|hnsw|annoy|numpy|torch|qdrant|custom
 ```
 
 Approximate Nearest Neighbor (ANN) index backend for storing generated sentence embeddings. `Defaults to faiss`. Additional backends require the
 [similarity](../../../install/#similarity) extras package to be installed. Add custom backends via setting this parameter to the fully resolvable
 class string.
 
-Backend-specific settings are set with a corresponding configuration object having the same name as the backend (i.e. annoy, faiss, or hnsw). None of these are required and are set to defaults if omitted.
+Backend-specific settings are set with a corresponding configuration object having the same name as the backend (i.e. annoy, faiss, hnsw or qdrant). These are optional and are set to defaults if omitted.
 
 ### faiss
+
 ```yaml
 faiss:
     components: comma separated list of components - defaults to "IDMap,Flat" for small
@@ -43,6 +45,7 @@ See the following Faiss documentation links for more information.
 - [Search Tuning](https://github.com/facebookresearch/faiss/wiki/Faster-search)
 
 ### hnsw
+
 ```yaml
 hnsw:
     efconstruction:  ef_construction param for init_index (int) - defaults to 200
@@ -54,6 +57,7 @@ hnsw:
 See [Hnswlib documentation](https://github.com/nmslib/hnswlib/blob/master/ALGO_PARAMS.md) for more information on these parameters.
 
 ### annoy
+
 ```yaml
 annoy:
     ntrees: number of trees (int) - defaults to 10
@@ -61,3 +65,23 @@ annoy:
 ```
 
 See [Annoy documentation](https://github.com/spotify/annoy#full-python-api) for more information on these parameters. Note that annoy indexes can not be modified after creation, upserts/deletes and other modifications are not supported.
+
+### qdrant
+
+```yaml
+embeddings:
+  path: sentence-transformers/all-MiniLM-L6-v2
+  backend: qdrant
+  metric: l1 # allowed values: l2 / cosine / ip / l1
+  qdrant:
+    url: http://localhost:6333/
+    collection: my-collection-name
+    api_key: XYZ # for Qdrant Cloud
+    collection_config:  # Reference: https://api.qdrant.tech/api-reference/collections/create-collection#request
+        on_disk_payload: true
+    search_params:  # Reference: https://api.qdrant.tech/api-reference/points/search-points#request.body.params
+        indexed_only: false
+
+```
+
+Refer to the [Qdrant documentation](https://qdrant.tech/documentation/) for more information on these parameters and setting up a Qdrant instance.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ extras["ann"] = [
     "hnswlib>=0.5.0",
     "pgvector>=0.2.5",
     "sqlalchemy>=2.0.20",
+    "qdrant-client>=1.9.0",
 ]
 
 extras["api"] = [

--- a/src/python/txtai/ann/__init__.py
+++ b/src/python/txtai/ann/__init__.py
@@ -9,4 +9,7 @@ from .faiss import Faiss
 from .hnsw import HNSW
 from .numpy import NumPy
 from .pgvector import PGVector
+from .qdrant import Qdrant
 from .torch import Torch
+
+__all__ = ["ANN", "ANNFactory", "Annoy", "Faiss", "HNSW", "NumPy", "PGVector", "Qdrant", "Torch"]

--- a/src/python/txtai/ann/factory.py
+++ b/src/python/txtai/ann/factory.py
@@ -9,6 +9,7 @@ from .faiss import Faiss
 from .hnsw import HNSW
 from .numpy import NumPy
 from .pgvector import PGVector
+from .qdrant import Qdrant
 from .torch import Torch
 
 
@@ -44,6 +45,8 @@ class ANNFactory:
             ann = NumPy(config)
         elif backend == "pgvector":
             ann = PGVector(config)
+        elif backend == "qdrant":
+            ann = Qdrant(config)
         elif backend == "torch":
             ann = Torch(config)
         else:

--- a/src/python/txtai/ann/qdrant.py
+++ b/src/python/txtai/ann/qdrant.py
@@ -1,0 +1,132 @@
+import warnings
+from txtai.ann import ANN
+
+try:
+    from grpc import RpcError
+    from qdrant_client import QdrantClient
+    from qdrant_client.http.exceptions import UnexpectedResponse
+    from qdrant_client.http.models import (
+        PointIdsList,
+        VectorParams,
+        Distance,
+        SearchRequest,
+        SearchParams,
+    )
+
+    QDRANT_INSTALLED = True
+except ImportError:
+    QDRANT_INSTALLED = False
+
+
+class Qdrant(ANN):
+    """
+    ANN implementation using Qdrant - https://qdrant.tech as a backend.
+    """
+
+    DISTANCE_MAPPING = {
+        "cosine": Distance.COSINE,
+        "l2": Distance.EUCLID,
+        "ip": Distance.DOT,
+        "l1": Distance.MANHATTAN,
+    }
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if not QDRANT_INSTALLED:
+            raise ImportError("'qdrant_client' is not installed. " "Install txtai with the 'ann' extra to enable Qdrant ANN backend.")
+        self.qdrant_config = self.config.get("qdrant", {})
+        self.collection_name = self.qdrant_config.get("collection", "txtai-embeddings")
+        self.qdrant_client = QdrantClient(
+            location=self.qdrant_config.get("location"),
+            url=self.qdrant_config.get("url"),
+            port=self.qdrant_config.get("port", 6333),
+            grpc_port=self.qdrant_config.get("grpc_port", 6334),
+            prefer_grpc=self.qdrant_config.get("prefer_grpc", False),
+            https=self.qdrant_config.get("https"),
+            api_key=self.qdrant_config.get("api_key"),
+            prefix=self.qdrant_config.get("prefix"),
+            timeout=self.qdrant_config.get("timeout"),
+            host=self.qdrant_config.get("host"),
+            path=self.qdrant_config.get("path"),
+            grpc_options=self.qdrant_config.get("grpc_options"),
+        )
+
+        # Initial offset is set to the number of existing rows
+        try:
+            self.config["offset"] = self.count()
+        except (UnexpectedResponse, RpcError, ValueError):
+            self.config["offset"] = 0
+
+    def index(self, embeddings):
+        vector_size = self.config.get("dimensions")
+        metric_name = self.config.get("metric", "cosine")
+        if metric_name not in self.DISTANCE_MAPPING:
+            raise ValueError(f"Unsupported Qdrant similarity metric: {metric_name}")
+        collection_config = self.qdrant_config.get("collection_config", {})
+
+        self.qdrant_client.recreate_collection(
+            collection_name=self.collection_name,
+            vectors_config=VectorParams(
+                size=vector_size,
+                distance=self.DISTANCE_MAPPING[metric_name],
+            ),
+            **collection_config,
+        )
+
+        self.config["offset"] = 0
+        self.append(embeddings)
+
+    def append(self, embeddings):
+        offset = self.config.get("offset", 0)
+        new_count = embeddings.shape[0]
+        ids = list(range(offset, offset + new_count))
+        self.qdrant_client.upload_collection(
+            collection_name=self.collection_name,
+            vectors=embeddings,
+            ids=ids,
+        )
+        self.config["offset"] += new_count
+
+    def delete(self, ids):
+        self.qdrant_client.delete(
+            collection_name=self.collection_name,
+            points_selector=PointIdsList(points=ids),
+        )
+
+    def search(self, queries, limit):
+        search_params = self.qdrant_config.get("search_params", {})
+        search_results = self.qdrant_client.search_batch(
+            collection_name=self.collection_name,
+            requests=[
+                SearchRequest(
+                    vector=query.tolist(),
+                    params=SearchParams(**search_params),
+                    limit=limit,
+                )
+                for query in queries
+            ],
+        )
+
+        results = []
+        for search_result in search_results:
+            results.append([(entry.id, entry.score) for entry in search_result])
+        return results
+
+    def count(self):
+        result = self.qdrant_client.count(
+            collection_name=self.collection_name,
+        )
+        return result.count
+
+    def load(self, path):
+        warnings.warn(
+            "Trying to call .load method on Qdrant ANN backend. " "This is redundant and won't have any effect.",
+            UserWarning,
+        )
+
+    def save(self, path):
+        warnings.warn(
+            "Trying to call .save method on Qdrant ANN backend. " "This is redundant and won't have any effect.",
+            UserWarning,
+        )

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -2,6 +2,8 @@
 Utils module
 """
 
+import requests
+
 
 class Utils:
     """
@@ -9,3 +11,14 @@ class Utils:
     """
 
     PATH = "/tmp/txtai"
+
+
+def qdrant_server_running() -> bool:
+    """Check if Qdrant server is running."""
+
+    try:
+        response = requests.get("http://localhost:6333", timeout=10.0)
+        response_json = response.json()
+        return response_json.get("title") == "qdrant - vector search engine"
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        return False


### PR DESCRIPTION
Hello 👋. Greetings from Qdrant.

## Description

This PR adds support for Qdrant to be used as an ANN backend. Currently, the integration is available as a separate package at https://github.com/qdrant/qdrant-txtai.

With the recent addition of PGVector, we are hoping txtai is now open to provide native support for external vector database providers.

## Testing
Tests have been configured to run using both an in-memory and Qdrant server instance.