### PR TITLE
Ensure config.path = None and config.path missing mean the same thing

### DIFF
--- a/src/python/txtai/embeddings/base.py
+++ b/src/python/txtai/embeddings/base.py
@@ -741,7 +741,7 @@ class Embeddings:
         self.scoring = self.createscoring() if scoring and (not isinstance(scoring, dict) or not scoring.get("terms")) else None
 
         # Dense vectors - transforms data to embeddings vectors
-        self.model = self.loadvectors() if self.config else None
+        self.model = self.loadvectors() if self.config and self.config.get("path") else None
 
         # Query model
         self.query = self.loadquery() if self.config else None

--- a/src/python/txtai/vectors/factory.py
+++ b/src/python/txtai/vectors/factory.py
@@ -42,7 +42,7 @@ class VectorsFactory:
             return WordVectors(config, scoring, models)
 
         # Default to TransformersVectors when configuration available
-        return TransformersVectors(config, scoring, models) if config and "path" in config else None
+        return TransformersVectors(config, scoring, models) if config.get("path") else None
 
     @staticmethod
     def method(config):


### PR DESCRIPTION
Previously if `path` was present, it was expected to have a value. This allows `path` to be `None`, and for `None` and empty to act in the same way.

Originally I made this change because setting `defaults` to `False` and `keyword` to `True` didn't seem to be enough for me.