### PR TITLE
Add bm25s library to benchmarks

### DIFF
--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -397,14 +397,14 @@ class BM25S(Index):
     def search(self, queries, limit):
         tokenizer = Tokenizer()
 
-        query_tokens = [tokenizer(x) for x in queries]
+        tokens = [tokenizer(x) for x in queries]
 
-        queried_results, queried_scores = self.backend.retrieve(query_tokens, corpus=self.corpus_ids, k=limit, n_threads=4)
+        results, scores = self.backend.retrieve(tokens, corpus=self.corpus_ids, k=limit, n_threads=4)
 
         # List of queries => list of matches (docid, score)
         x = []
 
-        for a, b in zip(queried_results, queried_scores):
+        for a, b in zip(results, scores):
             x.append([(str(c), float(d)) for c, d in zip(a, b)])
 
         return x
@@ -423,12 +423,12 @@ class BM25S(Index):
         if os.path.exists(self.output) and not self.refresh:
             model = bm25s.BM25.load(self.output)
         else:
-            corpus_tokens = [tokenizer(x) for x in corpus_lst]
+            tokens = [tokenizer(x) for x in corpus_lst]
 
             del corpus_lst
 
             model = bm25s.BM25(method="lucene", k1=1.2, b=0.75)
-            model.index(corpus_tokens, leave_progress=False)
+            model.index(tokens, leave_progress=False)
 
             model.save(self.output)
 

--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -424,14 +424,19 @@ class BM25S(Index):
 
         self.corpus_ids = corpus_ids
 
-        corpus_tokens = bm25s.tokenize(
-            corpus_lst, stemmer=self.stemmer, leave=False
-        )
+        if os.path.exists(self.output) and not self.refresh:
+            model = bm25s.BM25.load(self.output)
+        else:
+            corpus_tokens = bm25s.tokenize(
+                corpus_lst, stemmer=self.stemmer, leave=False
+            )
 
-        del corpus_lst
+            del corpus_lst
 
-        model = bm25s.BM25(method="lucene", k1=1.2, b=0.75)
-        model.index(corpus_tokens, leave_progress=False)
+            model = bm25s.BM25(method="lucene", k1=1.2, b=0.75)
+            model.index(corpus_tokens, leave_progress=False)
+
+            model.save(self.output)
 
         return model
 

--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -24,11 +24,11 @@ from pytrec_eval import RelevanceEvaluator
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk
 
+import bm25s
+
 from txtai.embeddings import Embeddings
 from txtai.pipeline import Extractor, LLM, Tokenizer
 from txtai.scoring import ScoringFactory
-
-import bm25s
 
 
 class Index:
@@ -399,15 +399,13 @@ class BM25S(Index):
 
         query_tokens = [tokenizer(x) for x in queries]
 
-        queried_results, queried_scores = self.backend.retrieve(
-            query_tokens, corpus=self.corpus_ids, k=limit, n_threads=4
-        )
+        queried_results, queried_scores = self.backend.retrieve(query_tokens, corpus=self.corpus_ids, k=limit, n_threads=4)
 
         # List of queries => list of matches (docid, score)
         x = []
 
         for a, b in zip(queried_results, queried_scores):
-            x.append( [ (str(c), float(d)) for c,d in zip(a, b) ] )
+            x.append([(str(c), float(d)) for c, d in zip(a, b)])
 
         return x
 

--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -2,7 +2,7 @@
 Runs benchmark evaluations with the BEIR dataset.
 
 Install txtai and the following dependencies to run:
-    pip install txtai pytrec_eval rank-bm25 elasticsearch psutil bm25s[full]
+    pip install txtai pytrec_eval rank-bm25 elasticsearch psutil bm25s
 """
 
 import argparse
@@ -28,7 +28,6 @@ from txtai.embeddings import Embeddings
 from txtai.pipeline import Extractor, LLM, Tokenizer
 from txtai.scoring import ScoringFactory
 
-import Stemmer
 import bm25s
 
 
@@ -396,9 +395,9 @@ class BM25S(Index):
     """
 
     def search(self, queries, limit):
-        query_tokens = bm25s.tokenize(
-            queries, stemmer=self.stemmer, leave=False
-        )
+        tokenizer = Tokenizer()
+
+        query_tokens = [tokenizer(x) for x in queries]
 
         queried_results, queried_scores = self.backend.retrieve(
             query_tokens, corpus=self.corpus_ids, k=limit, n_threads=4
@@ -413,8 +412,7 @@ class BM25S(Index):
         return x
 
     def index(self):
-        self.stemmer = Stemmer.Stemmer("english")
-
+        tokenizer = Tokenizer()
         corpus_ids = []
         corpus_lst = []
 
@@ -427,9 +425,7 @@ class BM25S(Index):
         if os.path.exists(self.output) and not self.refresh:
             model = bm25s.BM25.load(self.output)
         else:
-            corpus_tokens = bm25s.tokenize(
-                corpus_lst, stemmer=self.stemmer, leave=False
-            )
+            corpus_tokens = [tokenizer(x) for x in corpus_lst]
 
             del corpus_lst
 

--- a/examples/benchmarks.py
+++ b/examples/benchmarks.py
@@ -425,8 +425,6 @@ class BM25S(Index):
         else:
             tokens = [tokenizer(x) for x in corpus_lst]
 
-            del corpus_lst
-
             model = bm25s.BM25(method="lucene", k1=1.2, b=0.75)
             model.index(tokens, leave_progress=False)
 


### PR DESCRIPTION
:wave: Hello! I've been tinkering with your benchmarking suite and added support for benchmarking bm25s which is a fast implementation of BM25 indexer and search.

This is mostly an adaptation of the code from https://www.kaggle.com/code/xhlulu/benchmark-bm25-on-beir

NDCG@10 on quora seems to line up between this and the original code, although not exactly the same.