### PR TITLE
Introducing txtai Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
     <a href="https://coveralls.io/github/neuml/txtai?branch=master">
         <img src="https://img.shields.io/coverallsCoverage/github/neuml/txtai" alt="Coverage Status">
     </a>
+    <a href="https://gurubase.io/g/txtai">
+        <img src="https://img.shields.io/badge/Gurubase-Ask%20txtai%20Guru-006BFF" alt="Gurubase">
+    </a>
 </p>
 
 txtai is an all-in-one embeddings database for semantic search, LLM orchestration and language model workflows.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [txtai Guru](https://gurubase.io/g/txtai) to Gurubase. txtai Guru uses the data from this repo and data from the [docs](https://neuml.github.io/txtai) to answer questions by leveraging the LLM.

In this PR, I showcased the "txtai Guru", which highlights that txtai now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable txtai Guru in Gurubase, just let me know that's totally fine.
