### PR TITLE
Macfaiss

### DIFF
--- a/docs/embeddings/configuration/ann.md
+++ b/docs/embeddings/configuration/ann.md
@@ -40,6 +40,8 @@ See the following Faiss documentation links for more information.
 - [Binary Indexes](https://github.com/facebookresearch/faiss/wiki/Binary-indexes)
 - [Search Tuning](https://github.com/facebookresearch/faiss/wiki/Faster-search)
 
+Note: For macOS users, an existing bug in an upstream package restricts the number of processing threads to 1. This limitation is managed internally to prevent system crashes.
+
 ### hnsw
 ```yaml
 hnsw:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,11 +101,13 @@ Segmentation faults and similar errors on macOS
 
 __Solution__
 
+
 Set the following environment parameters.
 
-- Disable OpenMP threading via the environment variable `export OMP_NUM_THREADS=1`
+- OpenMP threading is handled internally on macOS platforms, but it can be disabled by setting the environment variable OMP_NUM_THREADS to 1, e.g., export OMP_NUM_THREADS=1. For more details, refer to the related discussion on GitHub: kyamagu/faiss-wheels#100.
 - Disable PyTorch MPS device via `export PYTORCH_MPS_DISABLE=1`
 - Disable llama.cpp metal via `export LLAMA_NO_METAL=1`
+
 
 ----------
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,7 +101,6 @@ Segmentation faults and similar errors on macOS
 
 __Solution__
 
-
 Set the following environment parameters.
 
 - OpenMP threading is handled internally on macOS platforms, but it can be disabled by setting the environment variable OMP_NUM_THREADS to 1, e.g., export OMP_NUM_THREADS=1. For more details, refer to the related discussion on GitHub: kyamagu/faiss-wheels#100.

--- a/src/python/txtai/ann/faiss.py
+++ b/src/python/txtai/ann/faiss.py
@@ -14,9 +14,10 @@ from faiss import index_binary_factory, read_index_binary, write_index_binary, I
 from .base import ANN
 
 if platform.system() == "Darwin":
-    # There is current a open Bug with OSX causing segmentation fault 
-    # seting the number of threads in FAISS to 1 fixes this until upstream create a patch
-    # ref: https://github.com/kyamagu/faiss-wheels/issues/100
+    # Workaround for an open bug on macOS causing segmentation faults in FAISS.
+    # Setting the number of threads in OpenMP to 1 avoids the issue for now.
+    # Ref: https://github.com/kyamagu/faiss-wheels/issues/100
+    # TODO: Remove this workaround once the upstream bug is patched.
     omp_set_num_threads(1)
 
 class Faiss(ANN):

--- a/src/python/txtai/ann/faiss.py
+++ b/src/python/txtai/ann/faiss.py
@@ -20,6 +20,7 @@ if platform.system() == "Darwin":
     # Remove this workaround once the upstream bug is patched.
     omp_set_num_threads(1)
 
+
 class Faiss(ANN):
     """
     Builds an ANN index using the Faiss library.

--- a/src/python/txtai/ann/faiss.py
+++ b/src/python/txtai/ann/faiss.py
@@ -17,7 +17,7 @@ if platform.system() == "Darwin":
     # Workaround for an open bug on macOS causing segmentation faults in FAISS.
     # Setting the number of threads in OpenMP to 1 avoids the issue for now.
     # Ref: https://github.com/kyamagu/faiss-wheels/issues/100
-    # TODO: Remove this workaround once the upstream bug is patched.
+    # Remove this workaround once the upstream bug is patched.
     omp_set_num_threads(1)
 
 class Faiss(ANN):

--- a/src/python/txtai/ann/faiss.py
+++ b/src/python/txtai/ann/faiss.py
@@ -3,14 +3,21 @@ Faiss module
 """
 
 import math
+import platform
 
 import numpy as np
 
+from faiss import omp_set_num_threads
 from faiss import index_factory, IO_FLAG_MMAP, METRIC_INNER_PRODUCT, read_index, write_index
 from faiss import index_binary_factory, read_index_binary, write_index_binary, IndexBinaryIDMap
 
 from .base import ANN
 
+if platform.system() == "Darwin":
+    # There is current a open Bug with OSX causing segmentation fault 
+    # seting the number of threads in FAISS to 1 fixes this until upstream create a patch
+    # ref: https://github.com/kyamagu/faiss-wheels/issues/100
+    omp_set_num_threads(1)
 
 class Faiss(ANN):
     """

--- a/test/python/testann.py
+++ b/test/python/testann.py
@@ -136,7 +136,7 @@ class TestANN(unittest.TestCase):
         # Validate count
         self.assertEqual(ann.count(), 100)
 
-    @patch('platform.system')
+    @patch("platform.system")
     def testFaissMacOS(self, mock_platform):
         """
         Test backend with OS Darwin

--- a/test/python/testann.py
+++ b/test/python/testann.py
@@ -137,7 +137,7 @@ class TestANN(unittest.TestCase):
         self.assertEqual(ann.count(), 100)
 
     @patch('platform.system')
-    def testmocdarwin(self, mock_platform):
+    def testFaissMacOS(self, mock_platform):
         """
         Test backend with OS Darwin
         """

--- a/test/python/testann.py
+++ b/test/python/testann.py
@@ -136,6 +136,14 @@ class TestANN(unittest.TestCase):
         # Validate count
         self.assertEqual(ann.count(), 100)
 
+    @patch('platform.system')
+    def testmocdarwin(self, mock_platform):
+        """
+        Test backend with OS Darwin
+        """
+        mock_platform.return_value = "Darwin"
+        self.runTests("faiss")
+
     @patch("sqlalchemy.orm.Query.limit")
     def testPGVector(self, query):
         """


### PR DESCRIPTION
This patch addresses a known issue on macOS where FAISS can cause a segmentation fault due to a bug with OpenMP threading. Explicitly setting the number of threads to 1 is a pragmatic temporary fix while we wait for an upstream resolution.