### PR TITLE
feat: add Tavily web search as agent tool option

### DIFF
--- a/docs/agent/configuration.md
+++ b/docs/agent/configuration.md
@@ -93,8 +93,8 @@ The following shortcut strings load tools directly. Passing a Tool instance is a
 | http.*      | HTTP Path to a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server |
 | python      | Runs a Python action                                      |
 | read        | Reads file or url content, supports text extraction       |
-| todowrite   | Generates a task list to organize complex tasks           |
 | tavily      | Runs a web search using the [Tavily API](https://tavily.com). Requires `TAVILY_API_KEY` env var and `tavily-python` package (install via `pip install txtai[agent-tavily]`) |
+| todowrite   | Generates a task list to organize complex tasks           |
 | websearch   | Runs a websearch using the built-in websearch tool        |
 | webview     | Extracts content from a web page. Alias for `read` tool   |
 | write       | Writes content to file                                    |

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ extras["dev"] = [
 
 extras["agent"] = ["jinja2>=3.1.6", "mcpadapt>=0.1.0", "smolagents>=1.23"]
 
+# Excluded from "all" — requires external Tavily API key
 extras["agent-tavily"] = extras["agent"] + ["tavily-python>=0.5.0"]
 
 extras["ann"] = [

--- a/src/python/txtai/agent/tool/factory.py
+++ b/src/python/txtai/agent/tool/factory.py
@@ -3,7 +3,6 @@ Factory module
 """
 
 import inspect
-import os
 
 from types import FunctionType, MethodType
 
@@ -22,56 +21,9 @@ from .glob import GlobTool
 from .grep import GrepTool
 from .read import ReadTool
 from .skill import SkillTool
+from .tavily import TavilySearchTool
 from .todo import TodoWriteTool
 from .write import WriteTool
-
-
-class TavilySearchTool(Tool):
-    """
-    Web search tool using the Tavily API.
-    """
-
-    name = "tavily_search"
-    description = "Performs a web search using the Tavily API and returns the top results."
-    inputs = {
-        "query": {"type": "string", "description": "The search query to perform."},
-    }
-    output_type = "string"
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        try:
-            from tavily import TavilyClient  # pylint: disable=C0415
-        except ImportError as e:
-            raise ImportError("tavily-python is required to use the tavily tool. Install it with: pip install tavily-python") from e
-
-        api_key = os.environ.get("TAVILY_API_KEY")
-        if not api_key:
-            raise EnvironmentError("TAVILY_API_KEY environment variable is required to use the tavily tool.")
-
-        self.client = TavilyClient(api_key=api_key)
-
-    def forward(self, query: str) -> str:
-        """
-        Runs a Tavily web search and returns formatted results.
-
-        Args:
-            query: search query
-
-        Returns:
-            formatted search results as a string
-        """
-
-        response = self.client.search(query=query, max_results=5, search_depth="basic")
-        results = []
-        for r in response.get("results", []):
-            title = r.get("title", "")
-            url = r.get("url", "")
-            content = r.get("content", "")
-            results.append(f"[{title}]({url})\n{content}")
-
-        return "\n\n".join(results) if results else "No results found."
 
 
 class ToolFactory:

--- a/src/python/txtai/agent/tool/tavily.py
+++ b/src/python/txtai/agent/tool/tavily.py
@@ -1,0 +1,55 @@
+"""
+Tavily module
+"""
+
+import os
+
+from smolagents import Tool
+
+
+class TavilySearchTool(Tool):
+    """
+    Web search tool using the Tavily API.
+    """
+
+    name = "tavily_search"
+    description = "Performs a web search using the Tavily API and returns the top results."
+    inputs = {
+        "query": {"type": "string", "description": "The search query to perform."},
+    }
+    output_type = "string"
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        try:
+            from tavily import TavilyClient  # pylint: disable=C0415
+        except ImportError as e:
+            raise ImportError("tavily-python is required to use the tavily tool. Install it with: pip install tavily-python") from e
+
+        api_key = os.environ.get("TAVILY_API_KEY")
+        if not api_key:
+            raise EnvironmentError("TAVILY_API_KEY environment variable is required to use the tavily tool.")
+
+        self.client = TavilyClient(api_key=api_key)
+
+    def forward(self, query: str) -> str:
+        """
+        Runs a Tavily web search and returns formatted results.
+
+        Args:
+            query: search query
+
+        Returns:
+            formatted search results as a string
+        """
+
+        response = self.client.search(query=query, max_results=5, search_depth="basic")
+        results = []
+        for r in response.get("results", []):
+            title = r.get("title", "")
+            url = r.get("url", "")
+            content = r.get("content", "")
+            results.append(f"[{title}]({url})\n{content}")
+
+        return "\n\n".join(results) if results else "No results found."


### PR DESCRIPTION
## Summary

- Added `TavilySearchTool`, a smolagents `Tool` subclass wrapping the Tavily search API, in `src/python/txtai/agent/tool/factory.py`
- Registered `"tavily"` as an on-demand tool name in `ToolFactory.create()` — created lazily only when requested, so existing behavior is unaffected
- Added `tavily-python>=0.5.0` as an optional dependency under a new `extras["agent-tavily"]` group in `setup.py`
- Documented the `tavily` tool shortcut and `TAVILY_API_KEY` env var requirement in `docs/agent/configuration.md`

## Files changed

- `src/python/txtai/agent/tool/factory.py` — new `TavilySearchTool` class + on-demand registration in `ToolFactory.create()`
- `setup.py` — new `agent-tavily` extras group with `tavily-python>=0.5.0`
- `docs/agent/configuration.md` — documented `tavily` tool in the tools table

## Dependency changes

- Added `tavily-python>=0.5.0` to new `extras["agent-tavily"]` group (install via `pip install txtai[agent-tavily]`)

## Environment variable changes

- `TAVILY_API_KEY` — required when using the `"tavily"` tool; not needed otherwise

## Notes for reviewers

- This is an **additive** change — existing `websearch` tool and all agent behavior remain completely untouched
- The Tavily tool is created on-demand (not eagerly in DEFAULTS) so missing `tavily-python` or `TAVILY_API_KEY` never affects module loading
- Clear error messages are raised if `tavily-python` is not installed or `TAVILY_API_KEY` is not set when the tool is requested


### Automated Review

- Passed after 2 attempt(s)
- Final review: The second-attempt migration is clean and correct. All four reported fixes from the prior review are properly addressed: TavilySearchTool is in its own dedicated module matching the codebase's architectural pattern, the docs table row is in alphabetical order (tavily before todowrite), the setup.py comment explains why agent-tavily is excluded from 'all', and factory.py imports and dispatches to TavilySearchTool correctly. The Tavily SDK usage is correct (class-level Tool attributes, lazy import of tavily-python, eager API key validation, correct response parsing). No regressions or unintended changes detected. One minor inconsistency: TavilySearchTool is not re-exported from __init__.py, but this matches WriteTool being absent from the same file — a pre-existing pattern that doesn't block approval.
