### PR TITLE
Add AG2 multi-agent RAG example with txtai

### DIFF
--- a/examples/85_AG2_Multiagent_RAG_with_txtai.ipynb
+++ b/examples/85_AG2_Multiagent_RAG_with_txtai.ipynb
@@ -1,0 +1,361 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d0",
+   "metadata": {},
+   "source": [
+    "# AG2 Multi-Agent RAG with txtai\n",
+    "\n",
+    "This notebook demonstrates how to use [AG2](https://ag2.ai/) (formerly AutoGen) multi-agent conversations with [txtai](https://neuml.github.io/txtai/) for Retrieval-Augmented Generation (RAG).\n",
+    "\n",
+    "**txtai** is an all-in-one AI framework with an embeddings database combining vector indexes, graph networks, and relational databases — enabling semantic search and serving as a powerful knowledge source for LLM applications.\n",
+    "\n",
+    "**AG2** is a multi-agent conversation framework with 500K+ monthly PyPI downloads, 4,300+ GitHub stars, and 400+ contributors.\n",
+    "\n",
+    "This example shows AG2 as an **alternative multi-agent orchestration layer** for txtai-powered RAG — complementing txtai's built-in agent system with AG2's multi-agent conversation patterns.\n",
+    "\n",
+    "Two AG2 agents collaborate:\n",
+    "- **Research Agent**: Retrieves relevant documents from txtai's embeddings database\n",
+    "- **Analyst Agent**: Synthesizes retrieved information into comprehensive answers"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d1",
+   "metadata": {},
+   "source": [
+    "# Install dependencies\n",
+    "\n",
+    "Install `txtai` and `ag2` with OpenAI support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%capture\n",
+    "!pip install -U txtai \"ag2[openai]>=0.11.4,<1.0\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from autogen import AssistantAgent, GroupChat, GroupChatManager, LLMConfig, UserProxyAgent\n",
+    "\n",
+    "import txtai\n",
+    "\n",
+    "# Set your OpenAI API key\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"your-api-key\"  # Replace with your key"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# Create txtai Embeddings Database\n",
+    "\n",
+    "Build an in-memory embeddings database with content storage enabled. txtai handles embedding generation internally — no external vector DB or embedding API needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create embeddings instance with content storage\n",
+    "# content=True enables returning full document text in search results\n",
+    "embeddings = txtai.Embeddings(content=True)\n",
+    "\n",
+    "# Sample documents about AI topics\n",
+    "documents = [\n",
+    "    (\n",
+    "        0,\n",
+    "        \"Retrieval-Augmented Generation (RAG) is a technique that combines information retrieval with language model generation. \"\n",
+    "        \"It first retrieves relevant documents from a knowledge base, then uses them as context for generating accurate, grounded \"\n",
+    "        \"responses. RAG reduces hallucination and enables models to access up-to-date information beyond their training data.\",\n",
+    "        None,\n",
+    "    ),\n",
+    "    (\n",
+    "        1,\n",
+    "        \"Vector databases store data as high-dimensional vectors (embeddings) and enable fast similarity search. txtai provides an \"\n",
+    "        \"all-in-one embeddings database that combines vector indexes with graph networks and relational databases, supporting both \"\n",
+    "        \"semantic and SQL-based queries.\",\n",
+    "        None,\n",
+    "    ),\n",
+    "    (\n",
+    "        2,\n",
+    "        \"Multi-agent systems use multiple AI agents that collaborate to solve complex tasks. Each agent can have specialized roles, \"\n",
+    "        \"tools, and knowledge. AG2 (formerly AutoGen) is a popular framework for building multi-agent conversations where agents can \"\n",
+    "        \"use tools, write code, and coordinate through structured dialogue patterns.\",\n",
+    "        None,\n",
+    "    ),\n",
+    "    (\n",
+    "        3,\n",
+    "        \"Embedding models convert text into dense numerical vectors that capture semantic meaning. Similar texts produce similar \"\n",
+    "        \"vectors, enabling semantic search. txtai uses sentence-transformers by default and supports custom embedding models \"\n",
+    "        \"via Hugging Face.\",\n",
+    "        None,\n",
+    "    ),\n",
+    "    (\n",
+    "        4,\n",
+    "        \"Chunking is the process of splitting documents into smaller pieces for embedding and retrieval. Common strategies include \"\n",
+    "        \"fixed-size chunking, recursive character splitting, and semantic chunking. Optimal chunk size depends on the use case: \"\n",
+    "        \"256-512 tokens for precise retrieval, 1000+ tokens for broader context.\",\n",
+    "        None,\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "# Index documents into txtai\n",
+    "embeddings.index(documents)\n",
+    "print(f\"Indexed {len(documents)} documents into txtai embeddings database\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d6",
+   "metadata": {},
+   "source": [
+    "# Test Semantic Search\n",
+    "\n",
+    "Verify that txtai retrieval works before connecting it to AG2 agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test search — txtai handles embedding + search internally\n",
+    "results = embeddings.search(\"What is RAG?\", limit=3)\n",
+    "\n",
+    "for result in results:\n",
+    "    # With content=True, results are dicts with id, score, text\n",
+    "    print(f\"Score: {result['score']:.4f}\")\n",
+    "    print(f\"  {result['text'][:100]}...\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d8",
+   "metadata": {},
+   "source": [
+    "# Define txtai Search Function for AG2\n",
+    "\n",
+    "Create a search function that AG2 agents will use as a registered tool to retrieve relevant documents from the txtai embeddings database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def search_txtai(query: str, top_k: int = 3) -> str:\n",
+    "    \"\"\"\n",
+    "    Search txtai embeddings database for relevant documents.\n",
+    "\n",
+    "    Args:\n",
+    "        query: Search query string.\n",
+    "        top_k: Number of results to return.\n",
+    "\n",
+    "    Returns:\n",
+    "        Formatted string with retrieved documents and scores.\n",
+    "    \"\"\"\n",
+    "    results = embeddings.search(query, limit=top_k)\n",
+    "\n",
+    "    formatted = []\n",
+    "    for i, result in enumerate(results, 1):\n",
+    "        score = result[\"score\"]\n",
+    "        text = result[\"text\"]\n",
+    "        formatted.append(f\"[{i}] (score: {score:.4f})\\n{text}\")\n",
+    "\n",
+    "    return \"\\n\\n---\\n\\n\".join(formatted) if formatted else \"No relevant documents found.\"\n",
+    "\n",
+    "\n",
+    "# Quick test\n",
+    "print(search_txtai(\"What is RAG?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3da",
+   "metadata": {},
+   "source": [
+    "# Set Up AG2 Multi-Agent System\n",
+    "\n",
+    "Create AG2 agents that collaborate to answer questions using txtai retrieval:\n",
+    "\n",
+    "1. **Research Agent** — Uses the `search_documents` tool to find relevant documents\n",
+    "2. **Analyst Agent** — Synthesizes retrieved information into a final answer\n",
+    "3. **User Proxy** — Orchestrates the conversation and executes tool calls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3db",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AG2 LLM Configuration\n",
+    "llm_config = LLMConfig({\"model\": \"gpt-4o-mini\", \"api_key\": os.environ[\"OPENAI_API_KEY\"], \"api_type\": \"openai\"})\n",
+    "\n",
+    "# Create agents\n",
+    "researcher = AssistantAgent(\n",
+    "    name=\"researcher\",\n",
+    "    system_message=(\n",
+    "        \"You are a research agent. When asked a question, use the search_documents \"\n",
+    "        \"tool to retrieve relevant documents from the txtai knowledge base. Present \"\n",
+    "        \"your findings clearly with relevance scores. If results are insufficient, \"\n",
+    "        \"try rephrasing your search query.\"\n",
+    "    ),\n",
+    "    llm_config=llm_config,\n",
+    ")\n",
+    "\n",
+    "analyst = AssistantAgent(\n",
+    "    name=\"analyst\",\n",
+    "    system_message=(\n",
+    "        \"You are an analyst. Based on the researcher's findings, synthesize the \"\n",
+    "        \"information into a comprehensive, well-structured answer. Always reference \"\n",
+    "        \"the retrieved content. End with TERMINATE when done.\"\n",
+    "    ),\n",
+    "    llm_config=llm_config,\n",
+    ")\n",
+    "\n",
+    "user_proxy = UserProxyAgent(\n",
+    "    name=\"user_proxy\",\n",
+    "    human_input_mode=\"NEVER\",\n",
+    "    max_consecutive_auto_reply=10,\n",
+    "    code_execution_config=False,\n",
+    "    is_termination_msg=lambda x: x.get(\"content\", \"\") and \"TERMINATE\" in x.get(\"content\", \"\"),\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Register txtai search as AG2 tool\n",
+    "@user_proxy.register_for_execution()\n",
+    "@researcher.register_for_llm(\n",
+    "    description=(\n",
+    "        \"Search the txtai embeddings database for relevant documents. \"\n",
+    "        \"Returns document chunks with similarity scores. \"\n",
+    "        \"Use specific search queries for best results.\"\n",
+    "    )\n",
+    ")\n",
+    "def search_documents(query: str, top_k: int = 3) -> str:\n",
+    "    \"\"\"Search txtai for relevant documents.\"\"\"\n",
+    "    return search_txtai(query, top_k)\n",
+    "\n",
+    "\n",
+    "# Set up GroupChat\n",
+    "group_chat = GroupChat(agents=[user_proxy, researcher, analyst], messages=[], max_round=12)\n",
+    "\n",
+    "manager = GroupChatManager(groupchat=group_chat, llm_config=llm_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3dc",
+   "metadata": {},
+   "source": [
+    "# Run Multi-Agent RAG Conversation\n",
+    "\n",
+    "The Research Agent will search txtai for relevant documents, and the Analyst Agent will synthesize the findings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_proxy.run(\n",
+    "    manager,\n",
+    "    message=\"What is RAG and how does it work with embeddings databases? Also explain how multi-agent systems can improve RAG quality.\",\n",
+    ").process()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3de",
+   "metadata": {},
+   "source": [
+    "# Summary\n",
+    "\n",
+    "This notebook demonstrated:\n",
+    "\n",
+    "1. **txtai** as an all-in-one embeddings database for semantic search\n",
+    "2. **AG2** multi-agent conversations with tool-calling capabilities\n",
+    "3. **Combining both**: AG2 agents using txtai search as a registered tool for grounded, retrieval-backed RAG responses\n",
+    "\n",
+    "## txtai vs AG2 Agents\n",
+    "\n",
+    "txtai includes its own agent system (built on smolagents). This notebook shows AG2 as a **complementary alternative** — useful when you need:\n",
+    "- Multi-agent conversation patterns (GroupChat, speaker selection)\n",
+    "- Integration with AG2's broader ecosystem (code execution, nested chats)\n",
+    "- Compatibility with existing AG2-based workflows\n",
+    "\n",
+    "## Key Components\n",
+    "\n",
+    "| Component | Role |\n",
+    "|-----------|------|\n",
+    "| **txtai Embeddings** | In-memory vector database with content storage |\n",
+    "| **AG2 UserProxy** | Orchestrates conversation, executes tools |\n",
+    "| **AG2 Research Agent** | Calls `search_documents` tool |\n",
+    "| **AG2 Analyst Agent** | Synthesizes findings into final answer |\n",
+    "\n",
+    "## Next Steps\n",
+    "\n",
+    "- Scale up with larger document collections and persistent storage\n",
+    "- Add more specialized agents (fact-checker, summarizer, etc.)\n",
+    "- Use txtai SQL queries for structured data retrieval\n",
+    "- Combine txtai pipelines (summarization, translation) as additional AG2 tools\n",
+    "- Explore txtai's graph network features for knowledge graph RAG\n",
+    "\n",
+    "## Resources\n",
+    "\n",
+    "- [AG2 Documentation](https://docs.ag2.ai/)\n",
+    "- [txtai Documentation](https://neuml.github.io/txtai/)\n",
+    "- [AG2 GitHub](https://github.com/ag2ai/ag2)\n",
+    "- [txtai GitHub](https://github.com/neuml/txtai)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "local",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.19"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Add an example notebook for [AG2](https://ag2.ai/) (formerly AutoGen), a multi-agent conversation framework.

- `examples/85_AG2_Multiagent_RAG_with_txtai.ipynb` — Complete notebook

## How it works

1. Documents are indexed into **txtai's embeddings database** (in-memory, content storage)
2. **AG2 Research Agent** uses a registered `search_documents` tool to query txtai
3. **AG2 Analyst Agent** synthesizes retrieved information into grounded answers
4. Agents collaborate via AG2 GroupChat with automatic tool execution

## Why AG2 + txtai?

txtai has excellent built-in agents (smolagents). This notebook shows AG2 as a **complementary alternative** — useful when you need multi-agent conversation patterns (GroupChat, speaker selection), nested chats, or integration with existing AG2-based workflows.

## Key features

- **Zero setup**: txtai in-memory embeddings, no external DB needed
- **Built-in embeddings**: txtai handles embedding generation internally
- **Multi-agent RAG**: Researcher retrieves, Analyst synthesizes
- **Tool registration**: txtai search exposed as AG2 tool via decorator pattern
- **Colab ready**: Can run directly in Google Colab

## Checklist

- [x] Notebook formatted with Black (150 char line length)
- [x] Valid .ipynb JSON structure
- [x] Follows existing example pattern (`NN_Title.ipynb` naming)
- [x] Self-contained and runnable
- [x] E2E tested with real API calls in clean venv
- [x] Positions AG2 as complement to txtai's built-in agents