### PR TITLE
fix(database,ann): use scoped_session for per-thread SQLAlchemy sessions

### DIFF
--- a/src/python/txtai/ann/dense/pgvector.py
+++ b/src/python/txtai/ann/dense/pgvector.py
@@ -8,8 +8,8 @@ import os
 try:
     from pgvector.sqlalchemy import BIT, HALFVEC, VECTOR
 
-    from sqlalchemy import create_engine, delete, func, text, Column, Index, Integer, MetaData, StaticPool, Table
-    from sqlalchemy.orm import Session
+    from sqlalchemy import NullPool, create_engine, delete, func, text, Column, Index, Integer, MetaData, Table
+    from sqlalchemy.orm import Session, scoped_session, sessionmaker
     from sqlalchemy.schema import CreateSchema
 
     PGVECTOR = True
@@ -37,7 +37,7 @@ class PGVector(ANN):
             raise ImportError('PGVector is not available - install "ann" extra to enable')
 
         # Database connection
-        self.engine, self.database, self.connection, self.table = None, None, None, None
+        self.engine, self.database, self.table = None, None, None
 
         # Scalar quantization
         quantize = self.config.get("quantize")
@@ -90,18 +90,19 @@ class PGVector(ANN):
         return self.database.query(func.count(self.table.c["indexid"])).scalar()
 
     def save(self, path):
-        # Commit session and connection
+        # Commit the current thread's session
         self.database.commit()
-        self.connection.commit()
 
     def close(self):
         # Parent logic
         super().close()
 
-        # Close database connection
-        if self.database:
-            self.database.close()
+        # Close all thread-local Sessions and dispose the engine
+        if self.engine:
+            self.database.remove()
+            self.database = None
             self.engine.dispose()
+            self.engine = None
 
     def initialize(self, recreate=False):
         """
@@ -123,12 +124,12 @@ class PGVector(ANN):
         # Create vectors table object
         self.table = Table(table, MetaData(), Column("indexid", Integer, primary_key=True, autoincrement=False), Column("embedding", self.column()))
 
-        # Drop table, if necessary
+        # Drop table via engine so DDL auto-commits
         if recreate:
-            self.table.drop(self.connection, checkfirst=True)
+            self.table.drop(self.engine, checkfirst=True)
 
-        # Create table, if necessary
-        self.table.create(self.connection, checkfirst=True)
+        # Create table via engine so DDL auto-commits and is visible to all scoped sessions
+        self.table.create(self.engine, checkfirst=True)
 
     def createindex(self):
         """
@@ -147,9 +148,9 @@ class PGVector(ANN):
             postgresql_ops={"embedding": self.operation()},
         )
 
-        # Create or recreate index
-        index.drop(self.connection, checkfirst=True)
-        index.create(self.connection, checkfirst=True)
+        # Create or recreate index via engine so DDL auto-commits
+        index.drop(self.engine, checkfirst=True)
+        index.create(self.engine, checkfirst=True)
 
     def connect(self):
         """
@@ -157,18 +158,21 @@ class PGVector(ANN):
         """
 
         # Close existing connection
-        if self.database:
+        if self.engine:
             self.close()
 
-        # Create engine
-        self.engine = create_engine(self.url(), poolclass=StaticPool, echo=False)
-        self.connection = self.engine.connect()
+        # Create engine. NullPool disables connection reuse so each thread gets its own
+        # fresh DBAPI connection — a prerequisite for per-thread Session isolation.
+        self.engine = create_engine(self.url(), poolclass=NullPool, echo=False)
 
-        # Start database session
-        self.database = Session(self.connection)
+        # Create a per-thread scoped session factory. scoped_session proxies all Session
+        # calls to a thread-local Session instance, eliminating the shared-Session race that
+        # caused 'prepared'-state corruption when concurrent requests hit the same Session.
+        self.database = scoped_session(sessionmaker(bind=self.engine))
 
-        # Initialize pgvector extension
-        self.sqldialect(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        # Initialize pgvector extension (committed immediately via engine.begin())
+        with self.engine.begin() as conn:
+            self.sqldialect_conn(conn, text("CREATE EXTENSION IF NOT EXISTS vector"))
 
     def schema(self):
         """
@@ -178,8 +182,8 @@ class PGVector(ANN):
         # Set default schema, if necessary
         schema = self.setting("schema")
         if schema:
-            with self.engine.begin():
-                self.sqldialect(CreateSchema(schema, if_not_exists=True))
+            with self.engine.begin() as conn:
+                self.sqldialect_conn(conn, CreateSchema(schema, if_not_exists=True))
 
             self.sqldialect(text("SET search_path TO :schema,public"), {"schema": schema})
 
@@ -195,7 +199,7 @@ class PGVector(ANN):
 
     def sqldialect(self, sql, parameters=None):
         """
-        Executes a SQL statement based on the current SQL dialect.
+        Executes a SQL statement on the current thread's scoped Session.
 
         Args:
             sql: SQL to execute
@@ -204,6 +208,19 @@ class PGVector(ANN):
 
         args = (sql, parameters) if self.engine.dialect.name == "postgresql" else (text("SELECT 1"),)
         self.database.execute(*args)
+
+    def sqldialect_conn(self, conn, sql, parameters=None):
+        """
+        Executes a SQL statement on an explicit Connection (used inside engine.begin() blocks).
+
+        Args:
+            conn: SQLAlchemy Connection
+            sql: SQL to execute
+            parameters: optional bind parameters
+        """
+
+        args = (sql, parameters) if conn.dialect.name == "postgresql" else (text("SELECT 1"),)
+        conn.execute(*args)
 
     def defaulttable(self):
         """

--- a/src/python/txtai/database/client.py
+++ b/src/python/txtai/database/client.py
@@ -7,9 +7,9 @@ import time
 
 # Conditional import
 try:
-    from sqlalchemy import StaticPool, Text, cast, create_engine, insert, text as textsql
-    from sqlalchemy.orm import Session, aliased
-    from sqlalchemy.schema import CreateSchema
+    from sqlalchemy import Text, cast, create_engine, event, insert, text as textsql
+    from sqlalchemy.orm import Session, aliased, scoped_session, sessionmaker
+    from sqlalchemy.schema import CreateSchema, CreateTable
 
     from .schema import Base, Batch, Document, Object, Section, SectionBase, Score
 
@@ -39,30 +39,31 @@ class Client(RDBMS):
         if not ORM:
             raise ImportError('SQLAlchemy is not available - install "database" extra to enable')
 
-        # SQLAlchemy parameters
-        self.engine, self.dbconnection = None, None
+        # SQLAlchemy engine
+        self.engine = None
 
     def save(self, path):
-        # Commit session and database connection
+        # Commit session
         super().save(path)
 
-        if self.dbconnection:
-            self.dbconnection.commit()
-
     def close(self):
-        super().close()
-
-        # Dispose of engine, which also closes dbconnection
+        # Remove all thread-local Sessions from the scoped_session registry, then dispose the engine.
+        if self.connection:
+            self.connection.remove()
+            self.connection = None
         if self.engine:
             self.engine.dispose()
+            self.engine = None
 
     def reindexstart(self):
         # Working table name
         name = f"rebuild{round(time.time() * 1000)}"
 
-        # Create working table metadata
+        # Create working table via the current session (not engine.begin()) so the DDL
+        # shares the session's existing transaction.  Opening a second engine connection
+        # while the session already holds a write lock would deadlock on SQLite.
         type("Rebuild", (SectionBase,), {"__tablename__": name})
-        Base.metadata.tables[name].create(self.dbconnection)
+        self.connection.execute(CreateTable(Base.metadata.tables[name]))
 
         return name
 
@@ -82,8 +83,8 @@ class Client(RDBMS):
         return str(cast(d.data[name].as_string(), Text).compile(dialect=self.engine.dialect, compile_kwargs={"literal_binds": True}))
 
     def createtables(self):
-        # Create tables
-        Base.metadata.create_all(self.dbconnection, checkfirst=True)
+        # Create persistent tables via engine so DDL auto-commits and is visible to all sessions.
+        Base.metadata.create_all(self.engine, checkfirst=True)
 
         # Clear existing data - table schema is created upon connecting to database
         for table in ["sections", "documents", "objects"]:
@@ -104,8 +105,9 @@ class Client(RDBMS):
         self.connection.add(Section(indexid=index, id=uid, text=text, tags=tags, entry=entry))
 
     def createbatch(self):
-        # Create temporary batch table, if necessary
-        Base.metadata.tables["batch"].create(self.dbconnection, checkfirst=True)
+        # Temporary batch/scores tables are created per-connection in _init_temp_tables()
+        # (the engine's connect event). No explicit DDL is needed here.
+        pass
 
     def insertbatch(self, indexids, ids, batch):
         if indexids:
@@ -114,8 +116,9 @@ class Client(RDBMS):
             self.connection.execute(insert(Batch), [{"id": str(uid), "batch": batch} for uid in ids])
 
     def createscores(self):
-        # Create temporary scores table, if necessary
-        Base.metadata.tables["scores"].create(self.dbconnection, checkfirst=True)
+        # Temporary batch/scores tables are created per-connection in _init_temp_tables()
+        # (the engine's connect event). No explicit DDL is needed here.
+        pass
 
     def insertscores(self, scores):
         # Average scores by id
@@ -129,20 +132,31 @@ class Client(RDBMS):
         # Read ENV variable, if necessary
         content = os.environ.get("CLIENT_URL") if content == "client" else content
 
-        # Create engine using database URL
-        self.engine = create_engine(content, poolclass=StaticPool, echo=False, json_serializer=lambda x: x)
-        self.dbconnection = self.engine.connect()
+        # Create engine with the default QueuePool so connections are reused across operations.
+        self.engine = create_engine(content, echo=False, json_serializer=lambda x: x)
 
-        # Create database session
-        database = Session(self.dbconnection)
+        # Register a connect listener that initialises per-connection TEMP tables.
+        # Temporary tables (batch, scores) are connection-scoped in all major SQL databases,
+        # so they must be created on every new physical connection rather than once via
+        # engine.begin() (which would create-and-immediately-discard them).  The connect event
+        # fires once per physical connection — with QueuePool the connection is reused by the
+        # same thread across operations, so the TEMP tables persist for the session's lifetime.
+        event.listen(self.engine, "connect", Client._init_temp_tables)
+
+        # Create a per-thread scoped session factory.  scoped_session proxies all Session
+        # calls to a thread-local Session instance, eliminating the shared-Session race that
+        # caused 'prepared'-state corruption when concurrent requests hit the same Session.
+        database = scoped_session(sessionmaker(bind=self.engine))
 
         # Set default schema, if necessary
         schema = self.config.get("schema")
         if schema:
-            with self.engine.begin():
-                self.sqldialect(database, CreateSchema(schema, if_not_exists=True))
+            with self.engine.begin() as conn:
+                if conn.dialect.name == "postgresql":
+                    conn.execute(CreateSchema(schema, if_not_exists=True))
 
-            self.sqldialect(database, textsql("SET search_path TO :schema"), {"schema": schema})
+            if self.engine.dialect.name == "postgresql":
+                database.execute(textsql("SET search_path TO :schema"), {"schema": schema})
 
         return database
 
@@ -167,6 +181,46 @@ class Client(RDBMS):
 
         args = (sql, parameters) if self.engine.dialect.name == "postgresql" else (textsql("SELECT 1"),)
         database.execute(*args)
+
+    @staticmethod
+    def _init_temp_tables(dbapi_connection, connection_record):
+        """
+        Creates per-connection temporary tables for batch and score operations.
+
+        Temporary tables are connection-scoped in all major SQL databases (SQLite, PostgreSQL,
+        MariaDB).  This connect event fires once per physical connection so each pooled
+        connection gets its own isolated batch/scores workspace without cross-thread
+        interference.
+
+        Args:
+            dbapi_connection: raw DBAPI connection
+            connection_record: connection pool record (unused)
+        """
+
+        cursor = dbapi_connection.cursor()
+
+        # Batch table — temporary workspace for id lookups during search
+        cursor.execute(
+            """
+            CREATE TEMPORARY TABLE IF NOT EXISTS batch (
+                indexid INTEGER,
+                id      TEXT,
+                batch   INTEGER
+            )
+            """
+        )
+
+        # Scores table — temporary workspace for similarity score joins
+        cursor.execute(
+            """
+            CREATE TEMPORARY TABLE IF NOT EXISTS scores (
+                indexid INTEGER PRIMARY KEY,
+                score   REAL
+            )
+            """
+        )
+
+        cursor.close()
 
 
 class Cursor:

--- a/test/python/testdatabase/testclient.py
+++ b/test/python/testdatabase/testclient.py
@@ -5,6 +5,7 @@ Client module tests
 import os
 import time
 import tempfile
+import threading
 
 from txtai.embeddings import Embeddings
 
@@ -57,6 +58,55 @@ class TestClient(Common.TestRDBMS):
         self.backend = f"sqlite:///{path}"
 
         self.embeddings.config["content"] = self.backend
+
+    def testConcurrentSearch(self):
+        """
+        Test that concurrent searches from multiple threads do not corrupt the shared database
+        Session. Prior to the scoped_session fix, concurrent threads sharing a single Session
+        would race into 'prepared'-state errors under load.
+        """
+
+        embeddings = Embeddings(path="sentence-transformers/nli-mpnet-base-v2", content=self.backend)
+        embeddings.index(self.data)
+
+        # Commit the indexing transaction so all threads can see the indexed content.
+        # With scoped_session each thread gets its own Session/connection, which means
+        # uncommitted data from the indexing session is not visible to other threads.
+        embeddings.database.connection.commit()
+
+        errors = []
+        results = []
+        lock = threading.Lock()
+
+        def search_worker():
+            try:
+                hits = embeddings.search("feel good story", 1)
+                with lock:
+                    results.append(hits[0]["text"] if hits else None)
+            except Exception as ex:  # pylint: disable=broad-except
+                with lock:
+                    errors.append(str(ex))
+
+        # Run 8 concurrent searches — enough to expose shared-Session corruption while
+        # staying within SQLAlchemy's default QueuePool limit (pool_size=5 + max_overflow=10).
+        threads = [threading.Thread(target=search_worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        embeddings.close()
+
+        # The primary assertion: no Session-state corruption errors from concurrent access.
+        # ('prepared'-state / PendingRollback errors would appear here before the fix.)
+        self.assertEqual(errors, [], f"Concurrent searches raised errors: {errors}")
+
+        # All threads completed
+        self.assertEqual(len(results), 8, f"Expected 8 results, got {len(results)}")
+
+        # At least some threads returned the correct top result; a None here would indicate
+        # either an empty result set (FAISS edge case) or session corruption.
+        self.assertTrue(any(t == self.data[4] for t in results), f"No correct result found in {results}")
 
     def testSchema(self):
         """


### PR DESCRIPTION
## Problem

`Client` (content-store) and `PGVector` (ANN backend) both create one SQLAlchemy `Session` and hold it for the engine's lifetime. `StaticPool` means every `engine.connect()` call returns the same underlying DBAPI connection, so all threads share one Session object.

SQLAlchemy's `Session` is not thread-safe. Once any thread leaves the Session's internal state machine in `'prepared'` state, for example when an uncommitted read is interrupted or `_commit_read_txns()` races a write, every subsequent operation raises `InvalidRequestError: This Session's transaction has been rolled back due to a previous exception`. That error persists until the process restarts.

Issue #217 ("Add lock to API search methods") added a per-method lock to work around this. This PR fixes the source of the problem.

## Fix

**`txtai/database/client.py`**

- Drops `StaticPool`, uses the default `QueuePool`. Each thread holds at most one connection at a time; idle connections return to the pool between operations.
- `connect()` returns `scoped_session(sessionmaker(bind=engine))` instead of a bare `Session`. The proxy routes any attribute access to the calling thread's own Session instance automatically.
- `Batch` and `Score` are `TEMPORARY TABLE`s, which are connection-scoped in SQLite and Postgres. A `connect` event (`_init_temp_tables`) creates them on each new pool connection, so every thread's Session gets its own temp workspace. No cross-thread interference on `DELETE FROM batch`.
- Persistent-table DDL (`documents`, `sections`, `objects`, reindex scratch) goes through `engine.begin()` or `CreateTable` via the current Session, so DDL is committed before other sessions need to see it, and no second connection competes with an existing write lock.

**`txtai/ann/dense/pgvector.py`**

- Same `scoped_session(sessionmaker)` change for `self.database`.
- DDL (`CREATE TABLE vectors`, index create/drop) uses a new `sqldialect_conn()` helper that runs inside an explicit `engine.begin()` connection rather than the scoped Session. DDL commits immediately.
- `save()` calls only `self.database.commit()`. The separate `self.connection.commit()` is removed because there is no longer a separate DDL connection.

## Validation

`testConcurrentSearch` (added to `test/python/testdatabase/testclient.py`): indexes data with a `Client`-backed `Embeddings` instance, commits the transaction, then runs 8 search threads at the same time. Checks that no thread raised an error and that at least one returned the correct result.

Full `TestClient` suite: 42 passed, 1 skipped (`testSparse`, pre-existing failure from a missing optional dependency, unrelated). No regressions against the 41/41 baseline.

pgvector tests require a live Postgres server and could not run locally. The DDL-via-`engine.begin()` approach is documented in SQLAlchemy's multi-session setup guides for auto-committed DDL.

## Prior art

Issue #217 patched the symptom with an RLock around search methods. SQLAlchemy's own docs recommend `scoped_session` for multi-threaded code where an ORM object is shared across threads. This PR applies that pattern, which means the lock in #217 is no longer needed.