### PR TITLE
fix(tokenizer): respect lowercase=False in ngramtokenize

### DIFF
--- a/src/python/txtai/pipeline/data/tokenizer.py
+++ b/src/python/txtai/pipeline/data/tokenizer.py
@@ -162,7 +162,7 @@ class Tokenizer(Pipeline):
         edge = self.ngrams.get("edge", False)
 
         # Split on non-whitespace and apply optional word padding
-        words = [f"{lpad}{x}{rpad}" for x in re.split(r"\W+", text.lower()) if x.strip()]
+        words = [f"{lpad}{x}{rpad}" for x in re.split(r"\W+", text) if x.strip()]
 
         # Generate ngrams
         ngrams = []

--- a/test/python/testpipeline/testdata/testtokenizer.py
+++ b/test/python/testpipeline/testdata/testtokenizer.py
@@ -51,3 +51,22 @@ class TestTokenizer(unittest.TestCase):
         for test, result in tests:
             # Unicode Text Segmentation per Unicode Annex #29
             self.assertEqual(tokenizer(test), result)
+
+    def testNgramLowercase(self):
+        """
+        Test that the lowercase parameter is honoured inside ngramtokenize.
+        Before the fix, text.lower() was called unconditionally inside
+        ngramtokenize, causing lowercase=False to be silently ignored.
+        """
+
+        # lowercase=False must preserve the original case of ngram tokens
+        tokenizer = Tokenizer(lowercase=False, ngrams=3)
+        result = tokenizer("CAT")
+        self.assertIn("CAT", result)
+        self.assertNotIn("cat", result)
+
+        # lowercase=True (default) must still produce lowercase ngrams
+        tokenizer = Tokenizer(lowercase=True, ngrams=3)
+        result = tokenizer("CAT")
+        self.assertIn("cat", result)
+        self.assertNotIn("CAT", result)


### PR DESCRIPTION
## Bug

`ngramtokenize` called `text.lower()` unconditionally, silently overriding `lowercase=False`. `__call__` already lowercases the input when `self.lowercase is True`, so the extra `.lower()` inside `ngramtokenize` was both redundant for the default case and wrong when `lowercase=False`.

```python
tokenizer = Tokenizer(lowercase=False, ngrams=3)
tokenizer('CAT')   # returned ['cat']  ← wrong; should be ['CAT']
```

## Fix

Remove the redundant `.lower()` from line 165 of `tokenizer.py` so that case handling is governed exclusively by `self.lowercase` in `__call__`, consistent with every other tokenization path (whitespace, regexp, segment).

## Verification

```
pytest test/python/testpipeline/testdata/testtokenizer.py -v
```

All 4 tests pass, including the new `testNgramLowercase` regression test.

> AI-assisted contribution