### PR TITLE
Fix EncodingAPIRoute to honour app-level dependencies via FastAPI effective route context

### DIFF
--- a/src/python/txtai/api/route.py
+++ b/src/python/txtai/api/route.py
@@ -2,7 +2,7 @@
 Route module
 """
 
-from fastapi.routing import APIRoute, get_request_handler
+from fastapi.routing import APIRoute, _effective_route_context_var, get_request_handler
 
 from .responses import ResponseFactory
 
@@ -20,22 +20,33 @@ class EncodingAPIRoute(APIRoute):
             route handler function
         """
 
+        # Read the effective route context NOW, while _effective_route_context_var is
+        # still set by APIRoute.handle.  The ContextVar is reset in a finally-block
+        # before the returned handler coroutine is ever awaited, so it must be
+        # captured here (synchronously) and held in the closure below.
+        effective_context = _effective_route_context_var.get()
+        route = (
+            effective_context
+            if effective_context is not None and effective_context.original_route is self
+            else self
+        )
+
         async def handler(request):
-            route = get_request_handler(
-                dependant=self.dependant,
-                body_field=self.body_field,
-                status_code=self.status_code,
+            handler_fn = get_request_handler(
+                dependant=route.dependant,
+                body_field=route.body_field,
+                status_code=route.status_code,
                 response_class=ResponseFactory.create(request),
-                response_field=getattr(self, "secure_cloned_response_field", self.response_field),
-                response_model_include=self.response_model_include,
-                response_model_exclude=self.response_model_exclude,
-                response_model_by_alias=self.response_model_by_alias,
-                response_model_exclude_unset=self.response_model_exclude_unset,
-                response_model_exclude_defaults=self.response_model_exclude_defaults,
-                response_model_exclude_none=self.response_model_exclude_none,
-                dependency_overrides_provider=self.dependency_overrides_provider,
+                response_field=getattr(route, "secure_cloned_response_field", route.response_field),
+                response_model_include=route.response_model_include,
+                response_model_exclude=route.response_model_exclude,
+                response_model_by_alias=route.response_model_by_alias,
+                response_model_exclude_unset=route.response_model_exclude_unset,
+                response_model_exclude_defaults=route.response_model_exclude_defaults,
+                response_model_exclude_none=route.response_model_exclude_none,
+                dependency_overrides_provider=route.dependency_overrides_provider,
             )
 
-            return await route(request)
+            return await handler_fn(request)
 
         return handler


### PR DESCRIPTION
## Bug

`testapi.testauthorization.TestAuthorization.testInvalid` has been failing on master: an unauthenticated `GET /search?query=test` returns `200` instead of the expected `401`.

## Root cause

FastAPI ≥ 0.94 propagates app-level and router-level dependencies to included routes through a `_effective_route_context_var` `ContextVar`.  The flow in `APIRoute.handle` is:

```python
token = _effective_route_context_var.set(effective_context)   # ← set
try:
    app = request_response(self.get_route_handler())           # ← get_route_handler called here
finally:
    _effective_route_context_var.reset(token)                  # ← reset BEFORE handler runs
await app(scope, receive, send)
```

`EncodingAPIRoute.get_route_handler()` overrides the base implementation to pick a per-request response class via `ResponseFactory`.  The override called `get_request_handler()` with `self.dependant` (the bare route dependant, which contains only per-route dependencies).  It never read `_effective_route_context_var`, so the app-level `Authorization` dependency was silently dropped for every route served by this router class.

Note: reading the ContextVar *inside* the inner `async def handler(request)` closure does not work because by the time that coroutine is awaited the ContextVar has already been reset in the `finally` block above.

## Fix

Read `_effective_route_context_var` **synchronously at the top of `get_route_handler()`**, while the ContextVar is still set.  Capture the result in the closure so that `get_request_handler()` receives the effective-context `dependant` (which contains the combined app + router + route dependencies) rather than the bare route dependant.

When no effective context is present (e.g. the initial startup call that creates `self.app`) the behaviour is unchanged: `self` is used as before.

Changed file: `src/python/txtai/api/route.py`

## Verification

```
# RED (before fix)
python -m unittest testapi.testauthorization -v
# testInvalid FAIL: 200 != 401

# GREEN (after fix)
python -m unittest testapi.testauthorization -v
# testInvalid ... ok
# testValid   ... ok
```

Broader `testapi.testextension` tests also pass.  Pre-existing failures in `testencoding` (`testMessagePack`, `testImages`, `testReadOnly`) are unrelated to this change and reproduce identically on unmodified master.