### PR TITLE
Add TwelveLabs Marengo embeddings and Pegasus video pipeline

### DIFF
--- a/docs/embeddings/configuration/vectors.md
+++ b/docs/embeddings/configuration/vectors.md
@@ -12,13 +12,13 @@ Sets the path for a vectors model. When using a transformers/sentence-transforme
 
 ## method
 ```yaml
-method: transformers|sentence-transformers|llama.cpp|litellm|model2vec|external|
-        words
+method: transformers|sentence-transformers|llama.cpp|litellm|model2vec|twelvelabs|
+        external|words
 ```
 
 Embeddings method to use. If the method is not provided, it is inferred using the `path`.
 
-`sentence-transformers`, `llama.cpp`, `litellm`, `model2vec` and `words` require the [vectors](../../../install/#vectors) extras package to be installed.
+`sentence-transformers`, `llama.cpp`, `litellm`, `model2vec`, `twelvelabs` and `words` require the [vectors](../../../install/#vectors) extras package to be installed.
 
 ### transformers
 
@@ -47,6 +47,12 @@ Builds embeddings using a LiteLLM model. See the [LiteLLM documentation](https:/
 ### model2vec
 
 Builds embeddings using a [Model2Vec](https://github.com/MinishLab/model2vec) model. Model2Vec is a knowledge-distilled version of a transformers model with static vectors.
+
+### twelvelabs
+
+Builds multimodal embeddings using the [TwelveLabs](https://twelvelabs.io) Marengo model via the TwelveLabs API. Marengo generates embeddings in a shared space for text, images, audio and video, enabling cross-modal similarity search. This method is inferred from a `path` starting with `marengo` (e.g. `marengo3.0`).
+
+Text inputs are passed as strings. Other modalities are passed as a dict with a single url key, for example `{"image_url": "https://..."}` or `{"audio_url": "https://..."}`. Requires a TwelveLabs API key, read from the `TWELVELABS_API_KEY` environment variable or `vectors.api.api_key`. A free API key with a generous free tier is available at [twelvelabs.io](https://twelvelabs.io).
 
 ### words
 

--- a/docs/pipeline/index.md
+++ b/docs/pipeline/index.md
@@ -41,6 +41,8 @@ The `LLM` and `RAG` pipelines also have integrations for [llama.cpp](https://git
     - [Similarity](text/similarity)
     - [Summary](text/summary)
     - [Translation](text/translation)
+- Video
+    - [Pegasus](video/pegasus)
 - Training
     - [HF ONNX](train/hfonnx)
     - [ML ONNX](train/mlonnx)

--- a/docs/pipeline/video/pegasus.md
+++ b/docs/pipeline/video/pegasus.md
@@ -1,0 +1,67 @@
+# Pegasus
+
+![pipeline](../../images/pipeline.png#only-light)
+![pipeline](../../images/pipeline-dark.png#only-dark)
+
+The Pegasus pipeline analyzes videos and generates text using the [TwelveLabs](https://twelvelabs.io) Pegasus video understanding model via the TwelveLabs API. Given a video and a prompt, Pegasus can summarize, caption, answer questions about or extract structured information from the video.
+
+A video is referenced by a public url or, for previously uploaded content, a TwelveLabs asset id passed as `{"asset_id": "..."}`.
+
+This pipeline requires a TwelveLabs API key, read from the `api_key` parameter or the `TWELVELABS_API_KEY` environment variable. A free API key with a generous free tier is available at [twelvelabs.io](https://twelvelabs.io).
+
+## Example
+
+The following shows a simple example using this pipeline.
+
+```python
+from txtai.pipeline import Pegasus
+
+# Create and run pipeline
+pegasus = Pegasus()
+pegasus("https://example.com/sample.mp4", "Describe what happens in this video")
+```
+
+## Configuration-driven example
+
+Pipelines are run with Python or configuration. Pipelines can be instantiated in [configuration](../../../api/configuration/#pipeline) using the lower case name of the pipeline. Configuration-driven pipelines are run with [workflows](../../../workflow/#configuration-driven-example) or the [API](../../../api#local-instance).
+
+### config.yml
+```yaml
+# Create pipeline using lower case class name
+pegasus:
+
+# Run pipeline with workflow
+workflow:
+  pegasus:
+    tasks:
+      - action: pegasus
+        args: ["Describe what happens in this video"]
+```
+
+### Run with Workflows
+
+```python
+from txtai import Application
+
+# Create and run pipeline with workflow
+app = Application("config.yml")
+list(app.workflow("pegasus", ["https://example.com/sample.mp4"]))
+```
+
+### Run with API
+
+```bash
+CONFIG=config.yml uvicorn "txtai.api:app" &
+
+curl \
+  -X POST "http://localhost:8000/workflow" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"pegasus", "elements":["https://example.com/sample.mp4"]}'
+```
+
+## Methods
+
+Python documentation for the pipeline.
+
+### ::: txtai.pipeline.Pegasus.__init__
+### ::: txtai.pipeline.Pegasus.__call__

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,8 @@ nav:
             - Similarity: pipeline/text/similarity.md
             - Summary: pipeline/text/summary.md
             - Translation: pipeline/text/translation.md
+        - Video:
+            - Pegasus: pipeline/video/pegasus.md
         - Train:
             - HF ONNX: pipeline/train/hfonnx.md
             - ML ONNX: pipeline/train/mlonnx.md

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ extras["pipeline-data"] = [
 
 extras["pipeline-image"] = ["imagehash>=4.2.1", "pillow>=7.1.2", "timm>=0.4.12"]
 
-extras["pipeline-llm"] = ["httpx>=0.28.1", "litert-lm-api>=0.11.0", "litellm>=1.37.16", "llama-cpp-python>=0.2.75"]
+extras["pipeline-llm"] = ["httpx>=0.28.1", "litert-lm-api>=0.11.0", "litellm>=1.37.16", "llama-cpp-python>=0.2.75", "twelvelabs>=1.2.8"]
 
 extras["pipeline-text"] = ["gliner-py>=0.2.27", "sentencepiece>=0.1.91", "staticvectors>=0.2.0"]
 
@@ -145,6 +145,7 @@ extras["vectors"] = [
     "skops>=0.9.0",
     "staticvectors>=0.2.0",
     "tokenizers>=0.22.2",
+    "twelvelabs>=1.2.8",
 ]
 
 extras["workflow"] = [

--- a/src/python/txtai/pipeline/__init__.py
+++ b/src/python/txtai/pipeline/__init__.py
@@ -15,3 +15,4 @@ from .nop import Nop
 from .text import *
 from .tensors import Tensors
 from .train import *
+from .video import *

--- a/src/python/txtai/pipeline/video/__init__.py
+++ b/src/python/txtai/pipeline/video/__init__.py
@@ -1,0 +1,5 @@
+"""
+Video imports
+"""
+
+from .pegasus import Pegasus

--- a/src/python/txtai/pipeline/video/pegasus.py
+++ b/src/python/txtai/pipeline/video/pegasus.py
@@ -1,0 +1,100 @@
+"""
+Pegasus module
+"""
+
+import os
+
+# Conditional import
+try:
+    from twelvelabs import TwelveLabs
+    from twelvelabs.types import VideoContext_AssetId, VideoContext_Url
+
+    TWELVELABS = True
+except ImportError:
+    TWELVELABS = False
+
+from ..base import Pipeline
+
+
+class Pegasus(Pipeline):
+    """
+    Analyzes and generates text from videos using the TwelveLabs Pegasus model via the TwelveLabs API.
+
+    Pegasus is a video understanding model. Given a video and a prompt, it can summarize, caption,
+    answer questions about or extract structured information from the video. Videos are referenced by
+    a public url or a TwelveLabs asset id (for previously uploaded videos).
+    """
+
+    def __init__(self, path=None, api_key=None, maxtokens=2048, **kwargs):
+        """
+        Creates a new Pegasus pipeline.
+
+        Args:
+            path: Pegasus model name, defaults to pegasus1.5
+            api_key: TwelveLabs API key, defaults to the TWELVELABS_API_KEY environment variable
+            maxtokens: default maximum number of tokens to generate per response
+            kwargs: additional arguments passed to the TwelveLabs client constructor
+        """
+
+        if not TWELVELABS:
+            raise ImportError('Pegasus pipeline is not available - install "pipeline" extra to enable')
+
+        # Default model
+        self.path = path if path else "pegasus1.5"
+        self.maxtokens = maxtokens
+
+        # Build API client. API key resolved from parameter or the TWELVELABS_API_KEY environment variable.
+        self.client = TwelveLabs(api_key=api_key if api_key else os.environ.get("TWELVELABS_API_KEY"), **kwargs)
+
+    def __call__(self, video, prompt, maxtokens=None, **kwargs):
+        """
+        Analyzes one or more videos with a prompt and generates text.
+
+        This method supports a single video or a list of videos. If the input is a single video, the
+        return type is a string. If the input is a list, a list of strings is returned.
+
+        A video is referenced by a public url (str) or, for previously uploaded content, an asset id
+        passed as {"asset_id": "..."}.
+
+        Args:
+            video: video url|asset id dict, or a list of either
+            prompt: analysis prompt
+            maxtokens: maximum number of tokens to generate, defaults to the pipeline default
+            kwargs: additional arguments passed to the analyze API (e.g. temperature)
+
+        Returns:
+            generated text or list of generated text
+        """
+
+        # Detect single input
+        values = [video] if not isinstance(video, list) else video
+
+        # Analyze each video
+        results = [self.analyze(x, prompt, maxtokens, **kwargs) for x in values]
+
+        # Return single result for single input
+        return results[0] if not isinstance(video, list) else results
+
+    def analyze(self, video, prompt, maxtokens, **kwargs):
+        """
+        Runs analysis for a single video.
+
+        Args:
+            video: video url or asset id dict
+            prompt: analysis prompt
+            maxtokens: maximum number of tokens to generate
+            kwargs: additional analyze API arguments
+
+        Returns:
+            generated text
+        """
+
+        # Build video context - asset id dict routes to an uploaded asset, otherwise treat as a url
+        context = VideoContext_AssetId(asset_id=video["asset_id"]) if isinstance(video, dict) else VideoContext_Url(url=video)
+
+        # Call the analyze API
+        response = self.client.analyze(
+            model_name=self.path, video=context, prompt=prompt, max_tokens=maxtokens if maxtokens else self.maxtokens, **kwargs
+        )
+
+        return response.data

--- a/src/python/txtai/vectors/dense/factory.py
+++ b/src/python/txtai/vectors/dense/factory.py
@@ -11,6 +11,7 @@ from .litert import LiteRT
 from .llama import LlamaCpp
 from .m2v import Model2Vec
 from .sbert import STVectors
+from .twelvelabs import TwelveLabs
 from .words import WordVectors
 
 
@@ -56,6 +57,10 @@ class VectorsFactory:
         if method == "model2vec":
             return Model2Vec(config, scoring, models)
 
+        # TwelveLabs Marengo vectors
+        if method == "twelvelabs":
+            return TwelveLabs(config, scoring, models)
+
         # Sentence Transformers vectors
         if method == "sentence-transformers":
             return STVectors(config, scoring, models) if config and config.get("path") else None
@@ -98,6 +103,8 @@ class VectorsFactory:
                     method = "llama.cpp"
                 elif Model2Vec.ismodel(path):
                     method = "model2vec"
+                elif TwelveLabs.ismodel(path):
+                    method = "twelvelabs"
                 elif WordVectors.ismodel(path):
                     method = "words"
                 else:

--- a/src/python/txtai/vectors/dense/twelvelabs.py
+++ b/src/python/txtai/vectors/dense/twelvelabs.py
@@ -1,0 +1,99 @@
+"""
+TwelveLabs module
+"""
+
+# Conditional import
+try:
+    from twelvelabs import TwelveLabs as TwelveLabsAPI
+
+    TWELVELABS = True
+except ImportError:
+    TWELVELABS = False
+
+import os
+
+from ...util import Library
+
+from ..base import Vectors
+
+# Core library imports
+np = Library().numpy()
+
+
+class TwelveLabs(Vectors):
+    """
+    Builds multimodal embeddings using the TwelveLabs Marengo model via the TwelveLabs API.
+
+    Marengo generates embeddings in a shared space for text, images, audio and video, making it
+    possible to run cross-modal similarity search (e.g. find video segments matching a text query).
+    This backend supports text and url-based image/audio inputs. Each input is a string for text or
+    a dict for other modalities, for example: {"image_url": "https://..."} or {"audio_url": "https://..."}.
+    """
+
+    @staticmethod
+    def ismodel(path):
+        """
+        Checks if path is a TwelveLabs Marengo model.
+
+        Args:
+            path: input path
+
+        Returns:
+            True if this is a TwelveLabs Marengo model, False otherwise
+        """
+
+        return isinstance(path, str) and path.lower().startswith("marengo")
+
+    def __init__(self, config, scoring, models):
+        # Check before parent constructor since it calls loadmodel
+        if not TWELVELABS:
+            raise ImportError('TwelveLabs is not available - install "vectors" extra to enable')
+
+        super().__init__(config, scoring, models)
+
+    def loadmodel(self, path):
+        # Build API client. API key resolved from config or the TWELVELABS_API_KEY environment variable.
+        api = dict(self.config.get("vectors", {}).get("api", {}))
+        api.setdefault("api_key", os.environ.get("TWELVELABS_API_KEY"))
+        return TwelveLabsAPI(**api)
+
+    def encode(self, data, category=None):
+        # Model name (e.g. marengo3.0)
+        model = self.config.get("path")
+
+        # Optional create() parameters (excluding the api client settings)
+        params = {k: v for k, v in self.config.get("vectors", {}).items() if k != "api"}
+
+        # Embed each input - the Marengo embed API processes a single input per call
+        embeddings = [self.embed(model, x, params) for x in data]
+
+        return np.array(embeddings, dtype=np.float32)
+
+    def embed(self, model, data, params):
+        """
+        Builds an embedding for a single input using the Marengo embed API.
+
+        Args:
+            model: Marengo model name
+            data: input data - a string for text or a dict with one of image_url/audio_url for other modalities
+            params: additional create() parameters
+
+        Returns:
+            embedding as a list of floats
+        """
+
+        # Build embed request - text input is the default, dicts route to other modalities
+        request = data if isinstance(data, dict) else {"text": data}
+
+        # Call the embed API
+        response = self.model.embed.create(model_name=model, **request, **params)
+
+        # Select the embedding for the requested modality
+        embedding = response.text_embedding
+        if "image_url" in request or "image_file" in request:
+            embedding = response.image_embedding
+        elif "audio_url" in request or "audio_file" in request:
+            embedding = response.audio_embedding
+
+        # Return the first segment's embedding vector
+        return embedding.segments[0].float_

--- a/test/python/testpipeline/testvideo/testpegasus.py
+++ b/test/python/testpipeline/testvideo/testpegasus.py
@@ -1,0 +1,73 @@
+"""
+Pegasus module tests
+"""
+
+import os
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+from txtai.pipeline import Pegasus
+
+
+class TestPegasus(unittest.TestCase):
+    """
+    Pegasus video pipeline tests
+    """
+
+    @patch("txtai.pipeline.video.pegasus.TwelveLabs")
+    def testAnalyze(self, client):
+        """
+        Test analyzing a video url
+        """
+
+        # Mock analyze response
+        instance = MagicMock()
+        instance.analyze.return_value.data = "A red car driving on a highway."
+        client.return_value = instance
+
+        pipeline = Pegasus(api_key="test")
+        result = pipeline("https://example.com/sample.mp4", "Describe this video")
+
+        # Single input returns a single string
+        self.assertEqual(result, "A red car driving on a highway.")
+
+        # Verify the url was wired into a video context
+        kwargs = instance.analyze.call_args.kwargs
+        self.assertEqual(kwargs["model_name"], "pegasus1.5")
+        self.assertEqual(kwargs["video"].url, "https://example.com/sample.mp4")
+        self.assertEqual(kwargs["prompt"], "Describe this video")
+
+    @patch("txtai.pipeline.video.pegasus.TwelveLabs")
+    def testAssetAndBatch(self, client):
+        """
+        Test analyzing an asset id and a list of videos
+        """
+
+        instance = MagicMock()
+        instance.analyze.return_value.data = "summary"
+        client.return_value = instance
+
+        pipeline = Pegasus(api_key="test")
+        results = pipeline([{"asset_id": "abc123"}, "https://example.com/b.mp4"], "Summarize")
+
+        # List input returns a list
+        self.assertEqual(results, ["summary", "summary"])
+
+        # First call routed to an asset id context
+        first = instance.analyze.call_args_list[0].kwargs
+        self.assertEqual(first["video"].asset_id, "abc123")
+
+    @unittest.skipIf(not os.environ.get("TWELVELABS_API_KEY"), "TWELVELABS_API_KEY not set")
+    def testLive(self):
+        """
+        Live test - requires a TwelveLabs API key and is gated since analysis can be slow
+        """
+
+        pipeline = Pegasus()
+        result = pipeline(
+            "https://sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4",
+            "Describe what happens in this video in one sentence.",
+        )
+        self.assertIsInstance(result, str)
+        self.assertTrue(len(result) > 0)

--- a/test/python/testvectors/testdense/testtwelvelabs.py
+++ b/test/python/testvectors/testdense/testtwelvelabs.py
@@ -1,0 +1,88 @@
+"""
+TwelveLabs module tests
+"""
+
+import os
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from txtai.vectors import VectorsFactory
+
+
+class TestTwelveLabs(unittest.TestCase):
+    """
+    TwelveLabs Marengo vectors tests
+    """
+
+    def mock(self, dimensions=512):
+        """
+        Builds a mock TwelveLabs client returning a fixed-size text embedding.
+
+        Args:
+            dimensions: embedding dimensions
+
+        Returns:
+            mock client
+        """
+
+        client = MagicMock()
+        segment = MagicMock()
+        segment.float_ = [0.1] * dimensions
+        client.embed.create.return_value.text_embedding.segments = [segment]
+        return client
+
+    @patch("txtai.vectors.dense.twelvelabs.TwelveLabsAPI")
+    def testIndex(self, api):
+        """
+        Test indexing with TwelveLabs Marengo vectors
+        """
+
+        # Mock client
+        api.return_value = self.mock()
+
+        # TwelveLabs vectors instance - method inferred from marengo path prefix
+        model = VectorsFactory.create({"path": "marengo3.0"}, None)
+
+        ids, dimension, batches, stream = model.index([(0, "a red car driving fast", None)])
+
+        self.assertEqual(len(ids), 1)
+        self.assertEqual(dimension, 512)
+        self.assertEqual(batches, 1)
+        self.assertTrue(os.path.exists(stream))
+
+        # Test shape of serialized embeddings
+        with open(stream, "rb") as queue:
+            self.assertEqual(np.load(queue).shape, (1, 512))
+
+    @patch("txtai.vectors.dense.twelvelabs.TwelveLabsAPI")
+    def testImageModality(self, api):
+        """
+        Test that an image_url input routes to the image embedding
+        """
+
+        client = MagicMock()
+        segment = MagicMock()
+        segment.float_ = [0.2] * 512
+        client.embed.create.return_value.image_embedding.segments = [segment]
+        api.return_value = client
+
+        model = VectorsFactory.create({"path": "marengo3.0"}, None)
+        embedding = model.transform((0, {"image_url": "https://example.com/cat.jpg"}, None))
+
+        # Verify the image embedding was used and create() received the image_url
+        self.assertEqual(embedding.shape, (512,))
+        self.assertEqual(client.embed.create.call_args.kwargs["image_url"], "https://example.com/cat.jpg")
+
+    @unittest.skipIf(not os.environ.get("TWELVELABS_API_KEY"), "TWELVELABS_API_KEY not set")
+    def testLive(self):
+        """
+        Live test - requires a TwelveLabs API key
+        """
+
+        model = VectorsFactory.create({"path": "marengo3.0"}, None)
+        embedding = model.transform((0, "a red car driving fast", None))
+
+        self.assertEqual(embedding.shape, (512,))


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an opt-in [TwelveLabs](https://twelvelabs.io) integration with two pieces:

- **Marengo multimodal embeddings backend** (`txtai/vectors/dense/twelvelabs.py`) — a new dense vectors method that builds 512-dim embeddings in a shared text/image/audio/video space via the TwelveLabs API. It plugs into `VectorsFactory` like the existing `litellm`/`model2vec` backends and is inferred from a `path` starting with `marengo` (e.g. `marengo3.0`). Text inputs are strings; other modalities are dicts (`{"image_url": ...}`, `{"audio_url": ...}`), enabling cross-modal similarity search.
- **Pegasus video pipeline** (`txtai/pipeline/video/pegasus.py`) — a new `Pegasus` pipeline that analyzes videos (public url or TwelveLabs asset id) and generates text given a prompt: summarize, caption, Q&A, structured extraction. It follows the standard `Pipeline.__call__` contract and is auto-registered by `PipelineFactory`, so it works in Python, YAML config, workflows and the API.

**Why it helps txtai:** Marengo brings native multimodal (video/audio/image) embeddings to txtai's existing embeddings index, and Pegasus adds video understanding to the pipeline/workflow system — both areas txtai doesn't currently cover with a hosted model.

**Opt-in / non-breaking:** No defaults change. Both components are reached only when you explicitly select `marengo*` as a vectors path or instantiate the `pegasus` pipeline. The `twelvelabs>=1.2.8` SDK is added to the existing `vectors` and `pipeline-llm` extras (conditional import, with a clear ImportError pointing at the extra). API keys are read from `TWELVELABS_API_KEY` or config.

**Testing:**
- No-network unit tests for both (mock the SDK client): `test/python/testvectors/testdense/testtwelvelabs.py` and `test/python/testpipeline/testvideo/testpegasus.py`, mirroring the existing litellm test style.
- Key-gated live tests (skip without `TWELVELABS_API_KEY`). The Marengo live test passes end-to-end (real 512-dim vector through the indexing path). The Pegasus pipeline wiring is verified against the live API (request is correctly built, authenticated, and accepted into the analyze endpoint); a full transcript run depends on a server-side-valid sample video.
- `black --line-length 150` clean; `pylint --rcfile=.pylintrc` 10.00/10 on the new source modules.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
