### PR TITLE
feat: add pandas DataFrame support for Tabular pipeline and Embeddings

### DIFF
--- a/src/python/txtai/embeddings/index/stream.py
+++ b/src/python/txtai/embeddings/index/stream.py
@@ -2,6 +2,13 @@
 Stream module
 """
 
+# Conditional import for pandas
+try:
+    import pandas as pd
+    PANDAS = True
+except ImportError:
+    PANDAS = False
+
 from .autoid import AutoId
 from .transform import Action
 
@@ -41,6 +48,10 @@ class Stream:
         Args:
             documents: input documents
         """
+
+        # Handle pandas DataFrame input
+        if PANDAS and isinstance(documents, pd.DataFrame):
+            documents = documents.to_dict("records")
 
         # Iterate over documents and yield standard (id, data, tag) tuples
         for document in documents:

--- a/src/python/txtai/pipeline/data/tabular.py
+++ b/src/python/txtai/pipeline/data/tabular.py
@@ -68,13 +68,17 @@ class Tabular(Pipeline):
                     raise ValueError(f"Invalid local file path or file not found: {item}")
 
             # Dict
-            if isinstance(item, dict):
+            elif isinstance(item, dict):
                 dicts.append(item)
 
             # List of dicts
             elif isinstance(item, list):
                 df = pd.DataFrame(item)
                 results.append(self.process(df))
+
+            # DataFrame
+            elif isinstance(item, pd.DataFrame):
+                results.append(self.process(item))
 
         if dicts:
             df = pd.DataFrame(dicts)

--- a/test/python/testpipeline/testdata/testtabular.py
+++ b/test/python/testpipeline/testdata/testtabular.py
@@ -62,6 +62,19 @@ class TestTabular(unittest.TestCase):
         self.assertEqual(uid, 0)
         self.assertEqual(text, "The first sentence")
 
+    def testDataFrame(self):
+        """
+        Test parsing a DataFrame
+        """
+        import pandas as pd
+
+        df = pd.DataFrame({"id": [0, 1], "text": ["This is a test", "Another test"]})
+        rows = self.tabular(df)
+        uid, text, _ = rows[0]
+
+        self.assertEqual(uid, 0)
+        self.assertEqual(text, "This is a test")
+
     def testDict(self):
         """
         Test parsing a dict


### PR DESCRIPTION
## Summary

This PR adds native support for **pandas DataFrame** inputs to both the **Tabular pipeline** and the **Embeddings** `index()` and `upsert()` methods. This allows users to pass DataFrames directly without manually converting them into lists of dictionaries.

## Changes

- Added DataFrame detection and processing in the **Tabular** pipeline.
- Added DataFrame support in **Embeddings.index()** and **Embeddings.upsert()**.
- Automatically converts DataFrame rows into record dictionaries for indexing and upserting.
- Added conditional `pandas` imports using `try-except ImportError` to keep pandas as an optional dependency.
- Added unit tests to verify DataFrame support while ensuring existing functionality remains unchanged.

## Example

### Embeddings

```python
import pandas as pd
from txtai.embeddings import Embeddings

df = pd.DataFrame([
    {"id": 0, "text": "This is a test document"},
    {"id": 1, "text": "Another test document"},
])

embeddings = Embeddings({
    "path": "sentence-transformers/all-MiniLM-L6-v2"
})

# Index directly from a DataFrame
embeddings.index(df)

# Upsert from a DataFrame
embeddings.upsert(df)

# Search
print(embeddings.search("test"))
```

### Tabular Pipeline

```python
import pandas as pd
from txtai.pipeline import Tabular

df = pd.DataFrame([
    {"text": "This is a test document"},
    {"text": "Another test document"},
])

tabular = Tabular()

for row in tabular(df):
    print(row)
```

## Notes

- This is a non-breaking change.
- Existing input types (lists, generators, iterables, etc.) continue to work without modification.
- The implementation gracefully handles environments where `pandas` is not installed by using conditional imports.