### PR TITLE
Raise SQLError on unterminated bracket, function and similar clauses

### DIFF
--- a/src/python/txtai/database/sql/expression.py
+++ b/src/python/txtai/database/sql/expression.py
@@ -202,6 +202,31 @@ class Expression:
         # Build alias text expression
         return ", ".join(expression)
 
+    def advance(self, iterator):
+        """
+        Advances the token iterator by one position. This is used when consuming the body of a bracket,
+        function or similar clause, all of which require a closing token. Raises a SQLError if the iterator
+        is exhausted before that closing token is found (i.e. an unterminated clause).
+
+        Args:
+            iterator: tokens iterator
+
+        Returns:
+            (position, token) for the next token
+
+        Raises:
+            SQLError: if the iterator has no more tokens (unterminated bracket, function or similar clause)
+        """
+
+        x, token = next(iterator, (None, None))
+        if x is None:
+            # Local import to avoid a circular import with the base module
+            from .base import SQLError  # pylint: disable=import-outside-toplevel
+
+            raise SQLError("Unterminated clause in SQL expression")
+
+        return x, token
+
     def bracket(self, iterator, tokens, x):
         """
         Consumes a [bracket] expression.
@@ -224,7 +249,7 @@ class Expression:
 
         # Read until token is a end bracket
         while token and (token != "]" or brackets > 0):
-            x, token = next(iterator, (None, None))
+            x, token = self.advance(iterator)
 
             # Increase/decrease bracket counter
             if token == "[":
@@ -263,7 +288,7 @@ class Expression:
 
         # Read until token is a closing paren
         while token and token != ")":
-            x, token = next(iterator, (None, None))
+            x, token = self.advance(iterator)
             if token and token not in ["(", ",", ")"]:
                 # Strip quotes and accumulate tokens
                 params.append(token.replace("'", "").replace('"', ""))
@@ -291,7 +316,7 @@ class Expression:
 
         # Consume function parameters
         while token and token != ")":
-            x, token = next(iterator, (None, None))
+            x, token = self.advance(iterator)
 
             # Check if token is a square bracket
             if Token.isbracket(token):

--- a/test/python/testdatabase/testsql.py
+++ b/test/python/testdatabase/testsql.py
@@ -70,6 +70,32 @@ class TestSQL(unittest.TestCase):
         with self.assertRaises(SQLError):
             self.db.search("select a b c from txtai where id match id")
 
+    def testUnterminated(self):
+        """
+        Test unterminated bracket, function and similar clauses raise SQLError instead of an internal error.
+        """
+
+        # Unterminated bracket expressions
+        with self.assertRaises(SQLError):
+            self.db.search("select [a from txtai")
+
+        with self.assertRaises(SQLError):
+            self.db.search("select avg([a) from txtai")
+
+        with self.assertRaises(SQLError):
+            self.db.search("select [a[0] from txtai")
+
+        # Unterminated function expressions
+        with self.assertRaises(SQLError):
+            self.db.search("select func(a from txtai")
+
+        with self.assertRaises(SQLError):
+            self.db.search("select * from txtai where coalesce(a")
+
+        # Unterminated similar clause
+        with self.assertRaises(SQLError):
+            self.db.search("select * from txtai where similar('abc'")
+
     def testBracket(self):
         """
         Test bracket expressions


### PR DESCRIPTION
## Summary

Malformed txtai SQL with an unterminated `[bracket]`, function or `similar(...)` clause crashes the parser with a cryptic `TypeError` instead of the `SQLError` the database layer documents (and callers catch) for invalid SQL.

```python
from txtai.database import DatabaseFactory, SQLError

db = DatabaseFactory.create({"content": True})
db.initialize()

db.search("select [a from txtai")
# TypeError: list indices must be integers or slices, not NoneType
```

## Root cause

The token-consumer loops in `Expression.bracket()`, `Expression.function()` and `Expression.similar()` (`src/python/txtai/database/sql/expression.py`) advance the token stream with `next(iterator, (None, None))` but never check for the end-of-stream sentinel. When a clause is left unterminated the iterator is exhausted, `x` becomes `None`, and the very next `tokens[x]` / `Token.iscolumn(tokens[x])` indexes `tokens[None]`:

```
File ".../database/sql/expression.py", line 240, in bracket
    tokens[x] = None
TypeError: list indices must be integers or slices, not NoneType
```

The parse step (`Database.parse` -> `SQL.__call__`) runs *before* the query reaches the database, so this `TypeError` escapes the `SQLError` wrapping in `Database.execute()` and reaches the caller raw. `Expression.compound()` already guards this exact case (`while token and Token.isoperator(token): ...` then `if token and ...`), so the three affected helpers were simply missing that same guard.

## Fix

Add `Expression.advance()`, a small helper that wraps `next()` and raises `SQLError` when the token stream is exhausted mid-clause, and route the three delimited consumer loops through it.

Auto-closing the clause instead was deliberately rejected: for a bounded clause like `select [a` the bracket body is only `[a`, so silently auto-closing would reinterpret it as the *valid* column `a` and mask the user's malformed input. Raising `SQLError` matches the documented contract and the existing `testBadSQL` expectations.

Behavior on **valid** queries is byte-identical — `advance()` only diverges from the old `next(iterator, (None, None))` path when the iterator is actually empty, which never happens for a well-formed clause.

## Before / after

| Query | Before | After |
|---|---|---|
| `select [a from txtai` | `TypeError: list indices ... NoneType` | `SQLError` |
| `select avg([a) from txtai` | `TypeError` | `SQLError` |
| `select [a[0] from txtai` | `TypeError` | `SQLError` |
| `select func(a from txtai` | `TypeError` | `SQLError` |
| `select * from txtai where coalesce(a` | `TypeError` | `SQLError` |
| `select * from txtai where similar('abc'` | `TypeError` | `SQLError` |
| `select [a] from txtai` (valid) | works | works (unchanged) |
| `select * from txtai where similar('abc')` (valid) | works | works (unchanged) |

## Tests

Added `testUnterminated` to `test/python/testdatabase/testsql.py` covering unterminated bracket, function and similar clauses.

Proof the test guards the bug (stashing only the source fix):

```
# with fix
17 passed in 0.05s

# git stash push -- src/python/txtai/database/sql/expression.py  (keep the test)
FAILED test/python/testdatabase/testsql.py::TestSQL::testUnterminated
E   TypeError: list indices must be integers or slices, not NoneType
src/python/txtai/database/sql/expression.py:240: TypeError
1 failed in 0.06s

# git stash pop  -> back to
17 passed
```

## Local verification

- `pytest test/python/testdatabase/testsql.py` -> **17 passed** (16 existing + new).
- `black --line-length 150 --check` on both changed files -> clean.
- `pylint -d import-error -d duplicate-code -d too-many-positional-arguments` (the repo's pre-commit args) on both changed files -> **10.00/10**.

The single deferred `from .base import SQLError` inside `advance()` breaks the module-level `base -> expression` import cycle; it carries an inline `# pylint: disable=import-outside-toplevel`, matching the existing `# pylint: disable=C0415` pattern in `src/python/txtai/util/library.py`.
