### PR TITLE
Add keyless Keenable web search agent tool

### DIFF
--- a/docs/agent/configuration.md
+++ b/docs/agent/configuration.md
@@ -91,6 +91,7 @@ The following shortcut strings load tools directly. Passing a Tool instance is a
 | glob        | Finds matching file patterns in a directory               |
 | grep        | Finds matching file content in a directory                |
 | http.*      | HTTP Path to a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server |
+| keenable    | Runs a web search using the [Keenable](https://keenable.ai) API (keyless; opt-in, not in `defaults`) |
 | python      | Runs a Python action                                      |
 | read        | Reads file or url content, supports text extraction       |
 | todowrite   | Generates a task list to organize complex tasks           |

--- a/src/python/txtai/agent/tool/__init__.py
+++ b/src/python/txtai/agent/tool/__init__.py
@@ -9,6 +9,7 @@ from .bash import BashTool
 from .edit import EditTool
 from .glob import GlobTool
 from .grep import GrepTool
+from .keenable import KeenableSearchTool
 from .read import ReadTool
 from .skill import SkillTool
 from .todo import TodoWriteTool

--- a/src/python/txtai/agent/tool/factory.py
+++ b/src/python/txtai/agent/tool/factory.py
@@ -19,6 +19,7 @@ from .embeddings import EmbeddingsTool
 from .function import FunctionTool
 from .glob import GlobTool
 from .grep import GrepTool
+from .keenable import KeenableSearchTool
 from .read import ReadTool
 from .skill import SkillTool
 from .todo import TodoWriteTool
@@ -30,7 +31,7 @@ class ToolFactory:
     Methods to create tools.
     """
 
-    # Default toolkit
+    # Default toolkit - included when "defaults" is specified
     DEFAULTS = {
         "bash": BashTool(),
         "edit": EditTool(),
@@ -42,6 +43,12 @@ class ToolFactory:
         "todowrite": TodoWriteTool(),
         "websearch": WebSearchTool(),
         "write": WriteTool(),
+    }
+
+    # Opt-in tools requested by name (not part of "defaults"). Keenable is keyless,
+    # so it needs no API key; an optional KEENABLE_API_KEY only lifts the rate limit.
+    OPTIN = {
+        "keenable": KeenableSearchTool(),
     }
 
     # Backwards compatible mappings
@@ -79,9 +86,9 @@ class ToolFactory:
                     else ToolFactory.createtool(target, tool)
                 )
 
-            # Get default tool, if applicable
-            elif isinstance(tool, str) and tool in ToolFactory.DEFAULTS:
-                tool = ToolFactory.DEFAULTS[tool]
+            # Get named tool (default or opt-in), if applicable
+            elif isinstance(tool, str) and (tool in ToolFactory.DEFAULTS or tool in ToolFactory.OPTIN):
+                tool = ToolFactory.DEFAULTS.get(tool) or ToolFactory.OPTIN[tool]
 
             # Get ALL default tools, if applicable
             elif isinstance(tool, str) and tool == "defaults":

--- a/src/python/txtai/agent/tool/keenable.py
+++ b/src/python/txtai/agent/tool/keenable.py
@@ -1,0 +1,69 @@
+"""
+Keenable web search tool
+"""
+
+import json
+import os
+
+from urllib.request import Request, urlopen
+
+from smolagents import Tool
+
+
+class KeenableSearchTool(Tool):
+    """
+    Web search tool powered by the Keenable API. Keyless by default: it calls the public endpoint with no
+    account or API key. Setting the KEENABLE_API_KEY environment variable only lifts the rate limit.
+    """
+
+    # pylint: disable=W0231
+    def __init__(self):
+        """
+        Creates a KeenableSearchTool.
+        """
+
+        # Tool parameters - distinct name to avoid collision with smolagents WebSearchTool
+        self.name = "keenable_search"
+        self.description = (
+            "Performs a web search using the Keenable API and returns relevant results. "
+            "Use this tool to find current information on any topic. No API key is required."
+        )
+        self.inputs = {
+            "query": {"type": "string", "description": "The search query to look up on the web."}
+        }
+        self.output_type = "string"
+
+        # Validate parameters and initialize tool
+        super().__init__()
+
+    # pylint: disable=W0221
+    def forward(self, query):
+        """
+        Runs a web search query using the Keenable API.
+
+        Args:
+            query: search query string
+
+        Returns:
+            formatted search results as a string
+        """
+
+        # Keyless by default; an optional key only lifts the rate limit
+        key = os.environ.get("KEENABLE_API_KEY")
+        url = "https://api.keenable.ai/v1/search" if key else "https://api.keenable.ai/v1/search/public"
+        headers = {"Content-Type": "application/json", "X-Keenable-Title": "txtai"}
+        if key:
+            headers["X-API-Key"] = key
+
+        data = json.dumps({"query": query, "mode": "pro"}).encode("utf-8")
+        with urlopen(Request(url, data=data, headers=headers, method="POST"), timeout=15) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        results = []
+        for result in payload.get("results", [])[:5]:
+            title = result.get("title", "")
+            link = result.get("url", "")
+            content = result.get("description", "")
+            results.append(f"[{title}]({link})\n{content}")
+
+        return "\n\n".join(results) if results else "No results found."


### PR DESCRIPTION
Closes #1127.

Adds an optional `keenable` agent tool for web search that works **with no API key**.

- **Keyless by default** — calls Keenable's public endpoint; no account or key required. An optional `KEENABLE_API_KEY` only lifts the rate limit.
- **No new dependency** — uses `urllib` from the standard library (no vendor SDK, no `setup.py` extras entry).
- **Opt-in** — exposed as the named tool `keenable` via a small `OPTIN` map in `ToolFactory`; it is not part of the `defaults` toolkit, so existing behavior is unchanged.

```python
from txtai.agent import Agent
agent = Agent(model="...", tools=["keenable"])
```

Files:
- `agent/tool/keenable.py` — `KeenableSearchTool` (mirrors the `smolagents.Tool` interface used by the other tools)
- `agent/tool/__init__.py`, `agent/tool/factory.py` — registration + `OPTIN` resolution
- `docs/agent/configuration.md` — tool table row

Verified: changed files compile, the tool instantiates, and `forward()` returns live keyless results (markdown-formatted like the other tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)