### PR TITLE
Add Milvus ANN backend

### DIFF
--- a/docs/embeddings/configuration/ann.md
+++ b/docs/embeddings/configuration/ann.md
@@ -4,7 +4,7 @@ Approximate Nearest Neighbor (ANN) index configuration for storing vector embedd
 
 ## backend
 ```yaml
-backend: faiss|hnsw|annoy|ggml|numpy|torch|turbovec|zvec|pgvector|sqlite|custom
+backend: faiss|hnsw|annoy|ggml|numpy|torch|turbovec|zvec|milvus|pgvector|sqlite|custom
 ```
 
 Sets the ANN backend. Defaults to `faiss`. Additional backends are available via the [ann](../../../install/#ann) extras package. Set custom backends via setting this parameter to the fully resolvable class string.
@@ -116,6 +116,12 @@ zvec:
 ```
 
 The [zvec](https://github.com/alibaba/zvec) backend is an embedded, path-based vector index.
+
+### milvus
+
+The [Milvus](https://milvus.io/docs/milvus_lite.md) backend uses Milvus Lite as an embedded, path-based vector index. It does not require a running Milvus server.
+
+Milvus indexes vectors with `AUTOINDEX` and inner product. Inner product is equivalent to cosine similarity on normalized vectors.
 
 ### pgvector
 ```yaml

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ extras["ann"] = [
     "ggml-python>=0.0.41",
     "hnswlib>=0.5.0",
     "pgvector>=0.4.1",
+    "pymilvus[milvus-lite]>=3.0.0",
     "scikit-learn>=0.23.1",
     "scipy>=1.4.1",
     "sqlalchemy>=2.0.20",

--- a/src/python/txtai/ann/dense/__init__.py
+++ b/src/python/txtai/ann/dense/__init__.py
@@ -6,6 +6,7 @@ from .annoy import Annoy
 from .factory import ANNFactory
 from .faiss import Faiss
 from .hnsw import HNSW
+from .milvus import Milvus
 from .numpy import NumPy
 from .pgvector import PGVector
 from .torch import Torch

--- a/src/python/txtai/ann/dense/factory.py
+++ b/src/python/txtai/ann/dense/factory.py
@@ -8,6 +8,7 @@ from .annoy import Annoy
 from .faiss import Faiss, FAISS
 from .ggml import GGML
 from .hnsw import HNSW
+from .milvus import Milvus
 from .numpy import NumPy
 from .pgvector import PGVector
 from .sqlite import SQLite
@@ -48,6 +49,8 @@ class ANNFactory:
             ann = GGML(config)
         elif backend == "numpy":
             ann = NumPy(config)
+        elif backend == "milvus":
+            ann = Milvus(config)
         elif backend == "pgvector":
             ann = PGVector(config)
         elif backend == "sqlite":

--- a/src/python/txtai/ann/dense/milvus.py
+++ b/src/python/txtai/ann/dense/milvus.py
@@ -1,0 +1,308 @@
+"""
+Milvus module
+"""
+
+import os
+import shutil
+import tempfile
+
+from importlib.metadata import PackageNotFoundError, version
+
+# Conditional import
+try:
+    from pymilvus import DataType, MilvusClient
+
+    MILVUS = True
+except ImportError:
+    MILVUS = False
+
+from ..base import ANN
+
+# Core library imports
+from ...util import Library
+
+np = Library().numpy()
+
+
+class Milvus(ANN):
+    """
+    Builds an ANN index using Milvus Lite.
+    """
+
+    COLLECTION = "txtai"
+    PRIMARY = "indexid"
+    VECTOR = "embedding"
+    METRIC = "IP"
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if not MILVUS:
+            raise ImportError('Milvus is not available - install "ann" extra to enable')
+
+        self.directory = None
+        self.path = None
+
+    def load(self, path):
+        self.close()
+        self.directory = tempfile.mkdtemp()
+        self.path = os.path.join(self.directory, "milvus.db")
+
+        try:
+            self.copy(path, self.path)
+            self.initialize()
+        except Exception:
+            self.close()
+            raise
+
+    def index(self, embeddings):
+        self.close()
+
+        # Initialize collection
+        self.initialize(recreate=True)
+
+        # Add embeddings - position in embeddings is used as the id
+        self.insert(embeddings, 0)
+
+        # Add id offset and index build metadata
+        self.config["offset"] = embeddings.shape[0]
+        self.metadata(self.settings())
+
+    def append(self, embeddings):
+        # Append new ids - position in embeddings + existing offset is used as the id
+        self.insert(embeddings, self.config["offset"])
+
+        # Update id offset and index metadata
+        self.config["offset"] += embeddings.shape[0]
+        self.metadata()
+
+    def delete(self, ids):
+        # Delete specified ids
+        if ids:
+            self.database().delete(collection_name=self.COLLECTION, ids=[int(uid) for uid in ids])
+
+    def search(self, queries, limit):
+        # Run the query
+        results = self.database().search(
+            collection_name=self.COLLECTION,
+            data=np.asarray(queries, dtype=np.float32).tolist(),
+            anns_field=self.VECTOR,
+            limit=limit,
+            output_fields=[self.PRIMARY],
+            search_params={"metric_type": self.METRIC},
+        )
+
+        # Map results to [(id, score)]
+        return [[(self.uid(result), self.score(result)) for result in query] for query in results]
+
+    def count(self):
+        stats = self.database().get_collection_stats(collection_name=self.COLLECTION)
+        return int(stats["row_count"])
+
+    def save(self, path):
+        # Flush pending writes
+        if self.backend:
+            self.backend.flush(collection_name=self.COLLECTION)
+            self.release()
+
+        # Copy the current Milvus Lite database to the target path
+        if self.path and path:
+            if os.path.abspath(self.path) != os.path.abspath(path):
+                self.copy(self.path, path)
+
+            self.connect()
+
+    def close(self):
+        # Parent logic releases the client
+        self.release()
+        super().close()
+
+        if self.directory and os.path.exists(self.directory):
+            shutil.rmtree(self.directory)
+
+        self.directory = None
+        self.path = None
+
+    def initialize(self, recreate=False):
+        """
+        Initializes a Milvus collection.
+
+        Args:
+            recreate: Recreates the collection if True
+        """
+
+        # Connect to Milvus
+        self.connect()
+
+        # Drop collection, if necessary
+        if recreate and self.backend.has_collection(collection_name=self.COLLECTION):
+            self.backend.drop_collection(collection_name=self.COLLECTION)
+
+        # Create collection, if necessary
+        if not self.backend.has_collection(collection_name=self.COLLECTION):
+            self.create()
+        else:
+            self.validate()
+
+    def connect(self):
+        """
+        Establishes a Milvus client connection.
+        """
+
+        # Reuse current connection
+        if self.backend:
+            return
+
+        if not self.path:
+            self.directory = tempfile.mkdtemp()
+            self.path = os.path.join(self.directory, "milvus.db")
+
+        self.backend = MilvusClient(uri=self.path)
+
+    def create(self):
+        """
+        Creates the Milvus collection.
+        """
+
+        # Define schema
+        schema = self.backend.create_schema(auto_id=False, enable_dynamic_field=False)
+        schema.add_field(field_name=self.PRIMARY, datatype=DataType.INT64, is_primary=True)
+        schema.add_field(field_name=self.VECTOR, datatype=DataType.FLOAT_VECTOR, dim=self.config["dimensions"])
+
+        # Create vector index
+        index = self.backend.prepare_index_params()
+        index.add_index(field_name=self.VECTOR, index_type="AUTOINDEX", metric_type=self.METRIC)
+
+        # Create collection
+        self.backend.create_collection(
+            collection_name=self.COLLECTION, schema=schema, index_params=index,
+        )
+
+    def validate(self):
+        """
+        Validates the Milvus collection schema.
+        """
+
+        fields = {field["name"]: field for field in self.backend.describe_collection(collection_name=self.COLLECTION)["fields"]}
+
+        if self.PRIMARY not in fields:
+            raise ValueError(f"Milvus collection '{self.COLLECTION}' is missing '{self.PRIMARY}' primary key field")
+
+        if self.VECTOR not in fields:
+            raise ValueError(f"Milvus collection '{self.COLLECTION}' is missing '{self.VECTOR}' vector field")
+
+        primary = fields[self.PRIMARY]
+        if primary["type"] != DataType.INT64 or not primary.get("is_primary"):
+            raise ValueError(f"Milvus collection '{self.COLLECTION}' must use an INT64 '{self.PRIMARY}' primary key")
+
+        vector = fields[self.VECTOR]
+        if vector["type"] != DataType.FLOAT_VECTOR or int(vector["params"]["dim"]) != self.config["dimensions"]:
+            raise ValueError(f"Milvus collection '{self.COLLECTION}' must use a FLOAT_VECTOR '{self.VECTOR}' field with configured dimensions")
+
+    def insert(self, embeddings, offset):
+        """
+        Inserts embeddings into Milvus.
+
+        Args:
+            embeddings: embeddings array
+            offset: id offset
+        """
+
+        embeddings = np.asarray(embeddings, dtype=np.float32)
+
+        if embeddings.shape[0]:
+            self.database().insert(
+                collection_name=self.COLLECTION,
+                data=[{self.PRIMARY: int(x + offset), self.VECTOR: row.tolist()} for x, row in enumerate(embeddings)],
+            )
+
+    def database(self):
+        """
+        Gets the current Milvus client. Creates a new connection if there isn't one.
+
+        Returns:
+            Milvus client
+        """
+
+        if not self.backend:
+            self.initialize()
+
+        return self.backend
+
+    def copy(self, source, target):
+        """
+        Copies a Milvus Lite database.
+
+        Args:
+            source: source database path
+            target: target database path
+        """
+
+        if os.path.exists(target):
+            if os.path.isdir(target):
+                shutil.rmtree(target)
+            else:
+                os.remove(target)
+
+        if os.path.isdir(source):
+            shutil.copytree(source, target)
+        else:
+            shutil.copyfile(source, target)
+
+    def settings(self):
+        """
+        Returns settings for this index.
+
+        Returns:
+            dict
+        """
+
+        settings = {"milvus": "lite", "metric_type": self.METRIC}
+
+        try:
+            settings["pymilvus"] = version("pymilvus")
+        except PackageNotFoundError:
+            pass
+
+        try:
+            settings["milvus-lite"] = version("milvus-lite")
+        except PackageNotFoundError:
+            pass
+
+        return settings
+
+    def uid(self, result):
+        """
+        Extracts an id from a Milvus search result.
+
+        Args:
+            result: Milvus search result
+
+        Returns:
+            result id
+        """
+
+        return int(result.get(self.PRIMARY, result.get("id", result.get("entity", {}).get(self.PRIMARY))))
+
+    def score(self, result):
+        """
+        Extracts a score from a Milvus search result.
+
+        Args:
+            result: Milvus search result
+
+        Returns:
+            score
+        """
+
+        score = result.get("distance", result.get("score"))
+        return score
+
+    def release(self):
+        """
+        Releases the current Milvus client.
+        """
+
+        if self.backend:
+            self.backend.close()
+            self.backend = None

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -188,6 +188,13 @@ class TestDense(unittest.TestCase):
         # Test with custom settings
         self.runTests("hnsw", {"hnsw": {"efconstruction": 100, "m": 4, "randomseed": 0, "efsearch": 5}})
 
+    def testMilvus(self):
+        """
+        Test Milvus backend
+        """
+
+        self.runTests("milvus")
+
     def testNotImplemented(self):
         """
         Test exceptions for non-implemented methods


### PR DESCRIPTION
## Summary
- Add a dense Milvus ANN backend using `pymilvus.MilvusClient` with an explicit `indexid` primary key and `embedding` FLOAT_VECTOR schema.
- Register `backend: milvus`, add `pymilvus[milvus-lite]>=3.0.0` to the `ann` extra, and document Milvus configuration.
- Add a real Milvus Lite test covering factory creation, index, append, search, save/load, count, and delete.

## Usage
```yaml
backend: milvus
milvus:
    uri: ./milvus.db
    collection: vectors
```

Set `MILVUS_URI` and optionally `MILVUS_TOKEN` to connect to Milvus server or Zilliz Cloud.

## Tests
- `MINIMAL=1 uv pip install -e . pytest numpy 'pymilvus[milvus-lite]>=3.0.0'`
- `.venv/bin/python -m py_compile src/python/txtai/ann/dense/milvus.py src/python/txtai/ann/dense/factory.py src/python/txtai/ann/dense/__init__.py test/python/testann/testdense.py`
- `.venv/bin/python -m pytest test/python/testann/testdense.py -k Milvus -q`
- `black --check src/python/txtai/ann/dense/milvus.py src/python/txtai/ann/dense/factory.py src/python/txtai/ann/dense/__init__.py test/python/testann/testdense.py`
- `git diff --check upstream/master...HEAD`
