### PR TITLE
Fix FileTask/UrlTask crash on non-string elements

### DIFF
--- a/src/python/txtai/workflow/task/file.py
+++ b/src/python/txtai/workflow/task/file.py
@@ -17,11 +17,15 @@ class FileTask(Task):
     FILE = r"file:\/\/"
 
     def accept(self, element):
+        # Only process string elements
+        if not isinstance(element, str):
+            return False
+
         # Replace file prefixes
         element = re.sub(FileTask.FILE, "", element)
 
         # Only accept file paths that exist
-        return super().accept(element) and isinstance(element, str) and os.path.exists(element)
+        return super().accept(element) and os.path.exists(element)
 
     def prepare(self, element):
         # Replace file prefixes

--- a/src/python/txtai/workflow/task/url.py
+++ b/src/python/txtai/workflow/task/url.py
@@ -17,4 +17,4 @@ class UrlTask(Task):
 
     def accept(self, element):
         # Only accept elements that start with a url prefix
-        return super().accept(element) and re.match(UrlTask.PREFIX, element.lower())
+        return super().accept(element) and isinstance(element, str) and re.match(UrlTask.PREFIX, element.lower())

--- a/test/python/testworkflow.py
+++ b/test/python/testworkflow.py
@@ -27,6 +27,7 @@ from txtai.workflow import (
     RetrieveTask,
     StorageTask,
     TemplateTask,
+    UrlTask,
     WorkflowTask,
 )
 
@@ -224,6 +225,27 @@ class TestWorkflow(unittest.TestCase):
         results = list(workflow([Utils.PATH + "/books.jpg"]))
 
         self.assertEqual(results[0].size, (1024, 682))
+
+    def testFileUrlTaskNonStringElements(self):
+        """
+        Test that FileTask/UrlTask/ImageTask pass through non-string and non-matching
+        elements instead of crashing, matching the base Task.accept contract for
+        heterogeneous batches.
+        """
+
+        with tempfile.NamedTemporaryFile() as temp:
+            # Elements: a real file path (matches FileTask), a url (matches UrlTask),
+            # a non-string, None and a non-matching string - none of these should crash.
+            data = [temp.name, "http://example.com", 5, None, "no match here"]
+
+            urls = list(Workflow([UrlTask(lambda x: [y.upper() for y in x])])(list(data)))
+            self.assertEqual(urls, [temp.name, "HTTP://EXAMPLE.COM", 5, None, "no match here"])
+
+            files = list(Workflow([FileTask(lambda x: [f.upper() for f in x])])(list(data)))
+            self.assertEqual(files, [temp.name.upper(), "http://example.com", 5, None, "no match here"])
+
+            images = list(Workflow([ImageTask()])(list(data)))
+            self.assertEqual(images, [temp.name, "http://example.com", 5, None, "no match here"])
 
     def testInvalidWorkflow(self):
         """


### PR DESCRIPTION
## Summary

`Task.accept()` is deliberately written to tolerate arbitrary element types (including `None`) so heterogeneous batches can flow through a multi-task workflow — a task that doesn't recognize an element should pass it through unchanged, not crash. `UrlTask.accept` and `FileTask.accept` override this but call `element.lower()` / `re.sub(..., element)` unconditionally, assuming `element` is already a string:

- `UrlTask.accept`: `super().accept(element)` short-circuits to `True` whenever the task has no `select` filter configured, so `element.lower()` runs next and raises `AttributeError` on any non-string element (including `None`).
- `FileTask.accept`: `re.sub(FileTask.FILE, "", element)` runs *before* the `isinstance(element, str)` check further down — so that check was dead code for the exact case it looked like it guarded against, and `re.sub` raises `TypeError` on any non-string element.

```python
from txtai.workflow import Workflow, UrlTask

task = UrlTask(lambda x: [u.upper() for u in x])
list(Workflow([task])(["http://example.com", None]))
# AttributeError: 'NoneType' object has no attribute 'lower'
```

Reachable through the documented multi-task/heterogeneous-batch pattern (e.g. a `WorkflowTask` + `FileTask` combo filtering mixed data by regex, as in the existing `testComplexWorkflow` test) — any batch containing a non-string value (`None` propagated from an upstream filtering step, or a numeric/dict payload) alongside url/file elements crashes instead of getting the intended pass-through treatment.

## Fix

Both `accept()` overrides now check `isinstance(element, str)` before doing string operations, so non-matching elements pass through unchanged instead of crashing. `ImageTask` inherits `FileTask.accept` and needed no code change — it's protected by the same fix via `and` short-circuit evaluation (verified in the added test).

## Testing

Added `testFileUrlTaskNonStringElements` to `test/python/testworkflow.py`, covering `UrlTask`/`FileTask`/`ImageTask` with a mixed batch (a real temp file path, a url, an int, `None`, and a non-matching string). Confirmed via `git stash` that it fails with the pre-fix `AttributeError`/`TypeError` and passes after the fix.

Ran the full `testworkflow.py` suite before/after: 14 pre-existing errors both times (all `ImportError: X is not available - install Y extra` from optional extras not installed in my dev environment, or network/model-download-dependent tests — unrelated to this change). My new test passes; no new failures introduced.

`pylint` (10.00/10) and `black --line-length 150` both clean on the changed files.

## AI disclosure

Developed with AI assistance (Claude Code), which located the crash via a targeted search across `workflow/task/` for `accept()` overrides that don't mirror the base class's type-tolerance, and noticed the `isinstance` check in `file.py` was unreachable given the line ordering. I reviewed the diff, independently reproduced both the pre-fix crash and the fix's correctness (including the `ImageTask` inheritance case) by executing them directly, and ran lint/tests myself before opening this PR.