### PR TITLE
Fix Graph.insert() node id desync when a document's text/object field is None

### DIFF
--- a/src/python/txtai/graph/base.py
+++ b/src/python/txtai/graph/base.py
@@ -409,6 +409,12 @@ class Graph:
             # Manually provided relationships and attributes to copy
             relations, attributes = None, {}
 
+            # Tracks whether this document consumes an indexid slot. Must match the same
+            # key-presence criterion Transform.stream() uses to compute its offset, so node
+            # ids stay in sync with the real vector index even when a text/object field is
+            # present but set to None.
+            hasfield = True
+
             # Extract data from dictionary
             if isinstance(document, dict):
                 # Extract relationships
@@ -423,18 +429,20 @@ class Graph:
                 }
 
                 # Require text or object field
+                hasfield = self.text in document or self.object in document
                 document = document.get(self.text, document.get(self.object))
 
-            if document is not None:
-                if isinstance(document, list):
-                    # Join tokens as text
-                    document = " ".join(document)
+            if hasfield:
+                if document is not None:
+                    if isinstance(document, list):
+                        # Join tokens as text
+                        document = " ".join(document)
 
-                # Create node
-                nodes.append((index, {**{"id": uid, "data": document}, **attributes}))
+                    # Create node
+                    nodes.append((index, {**{"id": uid, "data": document}, **attributes}))
 
-                # Add relationships
-                self.addrelations(index, relations)
+                    # Add relationships
+                    self.addrelations(index, relations)
 
                 index += 1
 

--- a/test/python/testgraph.py
+++ b/test/python/testgraph.py
@@ -188,6 +188,30 @@ class TestGraph(unittest.TestCase):
         self.assertTrue(graph.hasedge(0))
         self.assertTrue(graph.hasedge(0, 1))
 
+    def testInsertNoneTextIndexSync(self):
+        """
+        Test that a document with a present but None text/object field consumes an
+        indexid slot without creating a node, keeping later node ids in sync with
+        the real vector index offset (which increments on key presence, not on the
+        resolved value being non-None - see Transform.stream()).
+        """
+
+        graph = GraphFactory.create({})
+        graph.initialize()
+
+        documents = [
+            ("d0", {"text": "alpha content"}, None),
+            ("d1", {"text": None}, None),
+            ("d2", {"text": "gamma content"}, None),
+        ]
+        graph.insert(documents, index=0)
+
+        # d1's slot (index 1) is consumed but has no node - d2 must land at index 2, not 1
+        self.assertTrue(graph.hasnode(0))
+        self.assertFalse(graph.hasnode(1))
+        self.assertTrue(graph.hasnode(2))
+        self.assertEqual(graph.node(2)["id"], "d2")
+
     def testFilter(self):
         """
         Test creating filtered subgraphs


### PR DESCRIPTION
## Summary

`Graph.insert()` decided whether a document consumed an `indexid` slot based on whether the resolved text/object value was **not `None`**. But the actual vector index offset, computed by `Transform.stream()` (`embeddings/index/transform.py`), increments based on **key presence** (`self.text in document[1]`), regardless of the value.

A document like `{"text": None}` consumes a real vector index slot (per `Transform.stream()`'s criterion) but was silently skipped by `Graph.insert()` without incrementing its own `index` counter — so every subsequent document in the batch got assigned to the wrong graph node id. This is a silent, permanent misattribution of node ids to the wrong document data whenever any indexed document has a `text`/`object` key present with value `None` (plausible with DB/pandas-sourced documents with nullable columns).

```python
graph.insert([
    ("d0", {"text": "alpha content"}, None),
    ("d1", {"text": None}, None),
    ("d2", {"text": "gamma content"}, None),
], index=0)
# before this fix: node 0 = d0, node 1 = d2 (wrong! d2's actual vector-index slot is 2, not 1)
# after this fix:  node 0 = d0, node 2 = d2 (node 1 correctly left empty - d1 consumed that slot)
```

## Fix

Track slot consumption with the same key-presence criterion `Transform.stream()` uses (`hasfield`), separately from whether a node actually gets created for that slot (still gated on the resolved value being non-`None`, so no node is created for a genuinely empty document — but the index still advances, leaving a gap instead of shifting every later id).

## Testing

Added `testInsertNoneTextIndexSync` to `test/python/testgraph.py`. Confirmed via `git stash` that it fails against the pre-fix code (`d2` lands at node id 1 instead of 2) and passes after.

- Ran the affected test plus `testEdges`/`testCustomBackend`/`testCustomBackendNotFound` — all pass, no regressions.
- `pylint` (10.00/10) clean on the changed files.

## AI disclosure

Developed with AI assistance (Claude Code), which located the mismatch by comparing `Graph.insert()`'s slot-consumption criterion against `Transform.stream()`'s offset-computation criterion. I reviewed the diff, independently verified the bug and the fix by executing both against the actual `Graph.insert()` method, and ran the tests/linters myself before opening this PR.