### PR TITLE
Fix Graph.filter() crash on ids that don't exist in the graph

### DIFF
--- a/src/python/txtai/graph/base.py
+++ b/src/python/txtai/graph/base.py
@@ -544,8 +544,13 @@ class Graph:
             # Unpack node and score, if available
             node, score = node if isinstance(node, tuple) else (node, None)
 
+            # Skip ids that don't exist in this graph
+            nodeattrs = self.node(node)
+            if nodeattrs is None:
+                continue
+
             # Add nodes
-            graph.addnode(node, **self.node(node))
+            graph.addnode(node, **nodeattrs)
 
             # Add score if present
             if score is not None:

--- a/test/python/testgraph.py
+++ b/test/python/testgraph.py
@@ -188,6 +188,26 @@ class TestGraph(unittest.TestCase):
         self.assertTrue(graph.hasedge(0))
         self.assertTrue(graph.hasedge(0, 1))
 
+    def testFilterUnknownId(self):
+        """
+        Test that filter() skips ids that don't exist in the graph instead of
+        crashing when unpacking self.node(node) (which returns None for a
+        missing node).
+        """
+
+        graph = GraphFactory.create({})
+        graph.initialize()
+        graph.addnode(0, id="a", data="hello")
+        graph.addnode(1, id="b", data="world")
+        graph.addedge(0, 1)
+
+        subgraph = graph.filter([0, 1, 99])
+
+        self.assertTrue(subgraph.hasnode(0))
+        self.assertTrue(subgraph.hasnode(1))
+        self.assertFalse(subgraph.hasnode(99))
+        self.assertTrue(subgraph.hasedge(0, 1))
+
     def testInsertNoneTextIndexSync(self):
         """
         Test that a document with a present but None text/object field consumes an


### PR DESCRIPTION
## Summary

`Graph.filter()` unpacked `self.node(node)` with `**` into `addnode()` for every input id, but `self.node()` returns `None` for an id not present in the graph. `**None` raises `TypeError` instead of the filter simply skipping an id it doesn't recognize — the docstring says `nodes` are "nodes to select", with no stated precondition that every id must already exist.

```python
graph.addnode(0, id="a", data="hello")
graph.addnode(1, id="b", data="world")
graph.filter([0, 1, 99])
# TypeError: NetworkX.addnode() argument after ** must be a mapping, not NoneType
```

A realistic trigger for this: a caller-supplied id list that includes a stale/deleted id, or an id from a different (mismatched) index.

## Fix

Skip ids where `self.node()` returns `None` instead of crashing.

## Testing

Added `testFilterUnknownId` to `test/python/testgraph.py`. Confirmed via `git stash` that it fails with the pre-fix `TypeError` and passes after; the known-good ids and their edge are still correctly included in the filtered subgraph.

- Ran the affected test plus `testInsertNoneTextIndexSync`/`testEdges` — no regressions.
- `pylint` (10.00/10) clean on the changed files.

## AI disclosure

Developed with AI assistance (Claude Code), which located the crash while investigating the `graph/base.py` module for defects, tracing `self.node()`'s `None` return contract against its unguarded use in `filter()`. I reviewed the diff, independently reproduced the crash and the fix by executing both against the actual method, and ran the tests/linters myself before opening this PR.