### PR TITLE
fix: Task.filteredrun crashes/corrupts output for single-action tasks with merge disabled

### DIFF
--- a/src/python/txtai/workflow/task/base.py
+++ b/src/python/txtai/workflow/task/base.py
@@ -120,7 +120,9 @@ class Task:
         results = self.execute([self.prepare(element) for _, element in data], executor)
 
         # Pack results back into elements
-        if self.merge:
+        # Single-action tasks are always flattened by postprocess (regardless of merge),
+        # so results is already a single per-element list - same condition as postprocess.
+        if self.merge or len(self.action) <= 1:
             elements = self.filteredpack(results, indexed, ids)
         else:
             elements = [self.filteredpack(r, indexed, ids) for r in results]

--- a/test/python/testworkflow.py
+++ b/test/python/testworkflow.py
@@ -278,6 +278,14 @@ class TestWorkflow(unittest.TestCase):
         results = list(workflow([(1, "text", "tags")]))
         self.assertEqual(results[0], (0, "text", None))
 
+        # Test no merge with a single-action task - postprocess already flattens single-action
+        # results regardless of merge, so filteredrun's merge branch must match that (not
+        # iterate over already-flat per-element results as if they were per-action lists)
+        task = Task(lambda x: [pow(y, 2) for y in x], merge=None)
+        workflow = Workflow([task])
+        results = list(workflow([2, 4, 6]))
+        self.assertEqual(results, [4, 16, 36])
+
     def testMergeUnbalancedWorkflow(self):
         """
         Test merge tasks with unbalanced outputs (i.e. one action produce more output than another for same input).


### PR DESCRIPTION
## Problem

`Task.postprocess()` unwraps single-action task results **before** checking `merge` (`if len(self.action) == 1: return self.single(outputs[0])`, checked ahead of the `if not self.merge: return outputs` branch) — so for a single-action task, `execute()`'s return value is already a flat per-element list, regardless of what `merge` is set to.

But `filteredrun()` branches purely on the truthiness of `self.merge`:

```python
if self.merge:
    elements = self.filteredpack(results, indexed, ids)
else:
    elements = [self.filteredpack(r, indexed, ids) for r in results]
```

For a single-action task with `merge=None`/falsy, this takes the `else` branch and iterates `for r in results`, treating each individual per-element **result** as if it were itself a full per-action results list to pass into `filteredpack()`. Depending on the result type this either crashes (`TypeError: 'int' object is not subscriptable` for non-indexable results) or silently corrupts the output (indexing into a string character-by-character — e.g. `t = Task(action=lambda x: [s.upper() for s in x], merge=None); t(['hello', 'world'])` returns `[['H', 'E'], ['W', 'O']]` instead of `['HELLO', 'WORLD']`).

## Fix

Branch on `self.merge or len(self.action) <= 1` in `filteredrun`, matching `postprocess`'s own precedence (single-action check first).

## Testing

- Added a single-action/`merge=None` case to `testMergeWorkflow` (the existing "Test no merge" case only covered a 2-action task, which takes the correct branch and can't expose this).
- Confirmed the bug independently with a standalone repro before writing the fix.
- Full `testworkflow.py` suite passes except two pre-existing failures unrelated to this change (missing optional NLTK/language-detection "pipeline" extras in this environment — `testMergeUnbalancedWorkflow` and `testBaseWorkflow`).
- `ruff check` — clean.
- xref: no open PR touches `workflow/task/base.py`.

## AI disclosure

Found via an AI-assisted code review pass (Claude Code) over `txtai/workflow/task/`. I personally reproduced the crash/corruption with a standalone script comparing `postprocess`'s and `filteredrun`'s branching conditions, verified the fix against single-action, multi-action, and merge-set cases, and ran the relevant test suite before submitting.