### PR TITLE
Fix Aggregate IndexError on a SQL query that matched nothing across shards

### DIFF
--- a/src/python/txtai/database/sql/aggregate.py
+++ b/src/python/txtai/database/sql/aggregate.py
@@ -32,8 +32,9 @@ class Aggregate(SQL):
         # Parse query
         query = super().__call__(query)
 
-        # Check if this is a SQL query
-        if "select" in query:
+        # Check if this is a SQL query with results. A sharded query that matches
+        # nothing across all shards yields empty results, so guard before indexing.
+        if "select" in query and results:
             # Get list of unique and aggregate columns. If no aggregate columns or order by found, skip
             columns = list(results[0].keys())
             aggcolumns = self.aggcolumns(columns)

--- a/test/python/testdatabase/testsql.py
+++ b/test/python/testdatabase/testsql.py
@@ -5,6 +5,7 @@ SQL module tests
 import unittest
 
 from txtai.database import DatabaseFactory, SQL, SQLError
+from txtai.database.sql import Aggregate
 
 
 class TestSQL(unittest.TestCase):
@@ -311,6 +312,21 @@ class TestSQL(unittest.TestCase):
         self.assertSql("where", prefix + "where (id = 1 AND id = 2) OR indexid = 3", "(s.id = 1 AND s.id = 2) OR s.indexid = 3")
         self.assertSql("where", prefix + "where f(id) = b(id)", "f(s.id) = b(s.id)")
         self.assertSql("where", prefix + "WHERE f(id)", "f(s.id)")
+
+    def testAggregateEmptyResults(self):
+        """
+        Test Aggregate returns empty results for a SQL query that matched nothing
+        (e.g. a sharded query with zero hits across all shards) instead of crashing.
+        """
+
+        aggregate = Aggregate()
+
+        # SQL query, no results across shards - must not raise IndexError
+        self.assertEqual(aggregate("select id, text, score from txtai where similar('x')", []), [])
+        # Non-SQL query with no results stays consistent
+        self.assertEqual(aggregate("plain text query", []), [])
+        # SQL query with results still aggregates as before
+        self.assertEqual(aggregate("select count(*) from txtai", [{"count(*)": 1}, {"count(*)": 2}]), [{"count(*)": 3}])
 
     def assertSql(self, clause, query, expected):
         """


### PR DESCRIPTION
## Bug

`Aggregate.__call__` takes the SQL-query branch whenever the parsed query has
a `select` clause and immediately does:

```python
if "select" in query:
    columns = list(results[0].keys())
```

with no empty-results guard. A sharded/clustered search whose SQL query
matches nothing across every shard produces an empty combined result list, so
`results[0]` raises `IndexError` and the whole batch search crashes.

The non-SQL branch already handles this correctly: it falls through to
`defaultsort()`, whose `if results and "score" in results[0]` guard returns
the empty list cleanly. So empty results are safe for a plain query but crash
for a SQL query — an inconsistency, not intended behavior.

This is reachable in production via `api/cluster.py:123`
(`self.aggregate(query, result)`), where `result` is the per-query list
extended across all shard responses and is empty when a SQL query such as
`select ... where similar('...')` finds no matches anywhere.

### Reproduction

```python
from txtai.database.sql import Aggregate
agg = Aggregate()
agg("select id, text, score from txtai where similar('nomatch')", [])
# -> IndexError: list index out of range
agg("plain text query", [])   # non-SQL control: returns [] fine
```

## Fix

Guard the SQL branch with `if "select" in query and results:` so an empty
result set falls through to `defaultsort()` and returns `[]`, matching the
non-SQL path. One-line change.

## Testing

Added `testAggregateEmptyResults` to `test/python/testdatabase/testsql.py`
(`Aggregate` had no direct unit test): asserts an empty-result SQL query
returns `[]` instead of raising, that the non-SQL empty case stays `[]`, and
that a SQL query *with* results still aggregates correctly (e.g.
`count(*)` merge). Confirmed red→green — the test fails with the exact
`IndexError: list index out of range` at `aggregate.py:38` before the fix and
passes after. Full `testsql` suite (18 tests) passes; black (line-length 150)
and pylint (10.00/10, repo disables) clean.

## Disclosure

Found via an AI-assisted review pass (Claude Code); I independently reproduced
the crash, confirmed the production call path through the cluster API, and
verified the fix and tests before submitting.