### PR TITLE
Fix HTMLToMarkdown crash on a meta description tag with no content attribute

### DIFF
--- a/src/python/txtai/pipeline/data/htmltomd.py
+++ b/src/python/txtai/pipeline/data/htmltomd.py
@@ -135,7 +135,7 @@ class HTMLToMarkdown(Pipeline):
         metadata = [f"**{title.text.strip()}**"] if title and title.text else []
 
         description = node.find("meta", attrs={"name": "description"})
-        if description and description["content"]:
+        if description and description.get("content"):
             metadata.append(f"\n*{description['content'].strip()}*")
 
         # Add separator

--- a/test/python/testpipeline/testdata/testtextractor.py
+++ b/test/python/testpipeline/testdata/testtextractor.py
@@ -140,6 +140,16 @@ class TestTextractor(unittest.TestCase):
         self.assertMarkdown("<p>This is a <strong><em>test</em></strong></p>", "This is a **test**")
         self.assertMarkdown("<p>This is a <em><strong>test</strong></em></p>", "This is a *test*")
 
+    def testHTMLMetadataNoContent(self):
+        """
+        Test HTML with a meta description tag that has no content attribute
+        """
+
+        # A <meta name="description"> without a content attribute must not crash
+        textractor = Textractor()
+        html = "<html><head><meta name='description'></head><body><p>This is a test</p></body></html>"
+        self.assertEqual(textractor(html), "This is a test")
+
     def testParagraphs(self):
         """
         Test extraction to paragraphs


### PR DESCRIPTION
## Bug

`HTMLToMarkdown.metadata()` guards the meta-description handling with:

```python
description = node.find("meta", attrs={"name": "description"})
if description and description["content"]:
    metadata.append(f"\n*{description['content'].strip()}*")
```

BeautifulSoup's tag subscript raises `KeyError` (not `None`) for a missing
attribute, so a document containing `<meta name="description">` with no
`content=` attribute crashes the whole extraction with `KeyError: 'content'`
before any body text is returned. Content-less meta tags are common in
real-world HTML.

### Reproduction

```python
from txtai.pipeline import Textractor
Textractor()("<html><head><meta name='description'></head><body><p>hi</p></body></html>")
# -> KeyError: 'content'
```

## Fix

Use `description.get("content")`, which returns `None` for a missing
attribute so the guard falls through cleanly. Line 139's
`description['content'].strip()` stays safe because it only runs once the
guard has confirmed a truthy content value.

## Testing

Added `testHTMLMetadataNoContent` to
`test/python/testpipeline/testdata/testtextractor.py`: a full HTML document
with a content-less `<meta name="description">` now extracts the body text
instead of raising. Confirmed red→green — the test fails with `KeyError:
'content'` before the fix and passes after. Existing `testtextractor` tests
are unaffected. black (line-length 150) and pylint (10.00/10, repo disables)
clean.

## Disclosure

Found via an AI-assisted review pass (Claude Code); I independently reproduced
the crash and verified the fix and test before submitting.