### PR TITLE
Fix TemplateTask.match KeyError when a rule key is missing from element

### DIFF
--- a/src/python/txtai/workflow/task/template.py
+++ b/src/python/txtai/workflow/task/template.py
@@ -90,7 +90,7 @@ class TemplateTask(Task):
         if self.rules and isinstance(element, dict):
             # Check if any rules are matched
             for key, value in self.rules.items():
-                if element[key] == value:
+                if key in element and element[key] == value:
                     return element[key]
 
         return None

--- a/test/python/testworkflow.py
+++ b/test/python/testworkflow.py
@@ -448,6 +448,11 @@ class TestWorkflow(unittest.TestCase):
         results = list(workflow([{"text": "prompt"}]))
         self.assertEqual(results[0], "This is a prompt")
 
+        # Test rule key missing from element
+        workflow = Workflow([TemplateTask(template="This is a {text}", rules={"category": "skip"})])
+        results = list(workflow([{"text": "prompt"}]))
+        self.assertEqual(results[0], "This is a prompt")
+
     def testTemplateRag(self):
         """
         Test rag template task


### PR DESCRIPTION
Bug: `TemplateTask.match()` does `element[key]`, which raises `KeyError` for any rule whose key isn't present in the element, instead of treating that as no match.

Fix: guard with `key in element` before the equality check.

Verified: new test red before fix (`KeyError`), green after; full `testworkflow.py` suite unaffected (pre-existing NLTK/network failures, unrelated); black/pylint clean.

---
AI disclosure: this PR (diagnosis, fix, and test) was generated with Claude Code (Anthropic) and verified locally by me before submitting.