### PR TITLE
Fix Terms KeyError on a query with no similar() clause

### DIFF
--- a/src/python/txtai/embeddings/search/terms.py
+++ b/src/python/txtai/embeddings/search/terms.py
@@ -37,8 +37,8 @@ class Terms:
                 # Parse query
                 parse = self.database.parse(query)
 
-                # Join terms from similar clauses
-                terms.append(" ".join(" ".join(s) for s in parse["similar"]))
+                # Join terms from similar clauses (absent when the query has no similar() clause)
+                terms.append(" ".join(" ".join(s) for s in parse.get("similar", [])))
 
             return terms
 

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -363,6 +363,23 @@ class TestEmbeddings(unittest.TestCase):
         uid = embeddings.search("feel good story", 1)[0][0]
         self.assertEqual(uid, 0)
 
+    def testTerms(self):
+        """
+        Test extracting keyword terms from queries
+        """
+
+        embeddings = Embeddings({"keyword": True, "content": True})
+        embeddings.index([(uid, text, None) for uid, text in enumerate(self.data)])
+
+        # Plain keyword query is returned unchanged
+        self.assertEqual(embeddings.terms("feel good story"), "feel good story")
+
+        # SQL query with a similar() clause extracts its terms
+        self.assertEqual(embeddings.terms("select id, text from txtai where similar('feel good story')"), "feel good story")
+
+        # SQL query without a similar() clause has no keyword terms (previously raised KeyError)
+        self.assertEqual(embeddings.terms("select id, text from txtai where id = 1"), "")
+
     def testQuantize(self):
         """
         Test scalar quantization


### PR DESCRIPTION
`Embeddings.terms()`/`batchterms()` read `parse["similar"]` unconditionally, but `SQL.__call__` only adds the `similar` key when the query has a `similar()` clause. A keyword-free SQL query (e.g. `select id, text from txtai where id = 1`) therefore raised `KeyError: 'similar'` instead of returning an empty term string. Other consumers of that key (`explain`, `scan`) already guard it with `if "similar" in query`.

Fix: `parse.get("similar", [])`. Added `testTerms` covering the keyword, similar-clause, and no-similar-clause paths.

Prepared with AI assistance and reviewed before submission.