### PR TITLE
Fix Terms.search AttributeError on an empty terms index

### DIFF
--- a/src/python/txtai/scoring/terms.py
+++ b/src/python/txtai/scoring/terms.py
@@ -181,6 +181,10 @@ class Terms:
             list of (id, score)
         """
 
+        # Nothing indexed - term database was never initialized (self.cursor is None)
+        if not self.ids:
+            return []
+
         # Initialize scores array
         scores = np.zeros(len(self.ids), dtype=np.float32)
 

--- a/test/python/testscoring/testkeyword.py
+++ b/test/python/testscoring/testkeyword.py
@@ -49,6 +49,21 @@ class TestKeyword(unittest.TestCase):
 
         self.runTests("txtai.scoring.BM25")
 
+    def testTermsEmpty(self):
+        """
+        Test searching a terms index with nothing indexed
+        """
+
+        # No documents ever inserted
+        scoring = ScoringFactory.create({"method": "bm25", "terms": True})
+        self.assertEqual(scoring.search("bear", 1), [])
+
+        # Documents present but all skipped (missing text field) - term database never initialized
+        scoring = ScoringFactory.create({"method": "bm25", "terms": True})
+        scoring.index([(0, {"other": "value"}, None)])
+        self.assertEqual(scoring.count(), 0)
+        self.assertEqual(scoring.search("bear", 1), [])
+
     def testCustomNotFound(self):
         """
         Test unresolvable custom method


### PR DESCRIPTION
A terms-based scoring index only initializes its term database (and `self.cursor`) when a document is actually inserted. Searching before any insert — a freshly created index, or one where every indexed document was skipped for lacking the text column — left `self.cursor` as `None`, so `Terms.search` raised `AttributeError: 'NoneType' object has no attribute 'execute'` instead of returning an empty result list.

Fix: short-circuit `search` when nothing is indexed (`self.ids` is empty iff no inserts occurred). Added `testTermsEmpty` covering both the never-indexed and all-skipped paths.

Prepared with AI assistance and reviewed before submission.