### PR TITLE
Fix console printing a traceback for a query with no results

### DIFF
--- a/src/python/txtai/console/base.py
+++ b/src/python/txtai/console/base.py
@@ -154,6 +154,11 @@ class Console(Cmd):
         else:
             results = self.app.search(query, limit=self.vlimit)
 
+        # No matches, nothing to render
+        if not results:
+            self.console.print("No results")
+            return
+
         columns, table = {}, Table(box=box.SQUARE, style="#03a9f4")
 
         # Build column list

--- a/test/python/testconsole.py
+++ b/test/python/testconsole.py
@@ -78,6 +78,18 @@ class TestConsole(unittest.TestCase):
 
         self.assertIn("tasks", self.command(".config"))
 
+    def testNoResults(self):
+        """
+        Test a query that matches nothing renders a message instead of a traceback
+        """
+
+        console = Console()
+        console.app = self.embeddings
+
+        output = self.command("select id, text from txtai where id = 'missing'", console)
+        self.assertNotIn("Traceback", output)
+        self.assertIn("No results", output)
+
     def testEmbeddings(self):
         """
         Test embeddings index


### PR DESCRIPTION
`Console.search` did `result = results[0]` with no guard, so a legal query that matches nothing (a filtered SQL `where` clause, or an empty index) raised `IndexError`. The REPL's `default()` catches it and prints the full traceback to the user instead of an empty-result message.

Fix: guard the empty case and print `No results`. Added `testNoResults`.

Prepared with AI assistance and reviewed before submission.