### PR TITLE
Raise SQLError on empty select expressions and a dangling AS

### DIFF
--- a/src/python/txtai/database/sql/expression.py
+++ b/src/python/txtai/database/sql/expression.py
@@ -186,6 +186,10 @@ class Expression:
             if x not in aliases.values():
                 alias = tokens[x]
 
+                # An empty expression (e.g. a stray comma in the select clause) has no alias
+                if not alias:
+                    raise SQLError("Empty expression in SQL clause")
+
                 # Strip leading/trailing brackets from alias name that doesn't have operators
                 if not any(Token.isoperator(t) for t in alias) and alias[0] in ("[", "(") and alias[-1] in ("]", ")"):
                     alias = alias[1:-1]
@@ -336,6 +340,10 @@ class Expression:
         # If this is an alias token, get next token
         if token in Token.ALIAS:
             x, token = next(iterator, (None, None))
+
+            # A trailing AS with no alias name exhausts the stream
+            if x is None:
+                raise SQLError("Missing alias name in SQL expression")
 
         # Consume tokens until end of stream or a separator is found. Evaluate next token to prevent consuming here.
         while x + 1 < len(tokens) and not Token.isseparator(Token.get(tokens, x + 1)):

--- a/test/python/testdatabase/testsql.py
+++ b/test/python/testdatabase/testsql.py
@@ -265,6 +265,22 @@ class TestSQL(unittest.TestCase):
         with self.assertRaises(SQLError):
             self.db.search("select * from txtai where similar('abc'")
 
+    def testMalformedExpression(self):
+        """
+        Test malformed select expressions raise a SQLError instead of an internal exception
+        """
+
+        # Empty select components (stray commas) raised IndexError
+        with self.assertRaises(SQLError):
+            self.db.search("select a,,b from txtai")
+
+        with self.assertRaises(SQLError):
+            self.db.search("select ,a from txtai")
+
+        # A trailing AS with no alias name raised TypeError
+        with self.assertRaises(SQLError):
+            self.db.search("select a as from txtai")
+
     def testUpper(self):
         """
         Test SQL statements are case insensitive.


### PR DESCRIPTION
Two malformed-select cases raised raw internal exceptions instead of `SQLError`:

- an empty select component (a stray comma, e.g. `select a,,b from txtai`) indexed `alias[0]` and raised `IndexError`;
- a trailing `AS` with no alias name (`select a as from txtai`) left the token position as `None` and raised `TypeError: NoneType + int`.

Both now raise `SQLError`, matching how the parser already reports unterminated bracket/function/similar clauses (`testUnterminated`). Valid queries — including `select a as col`, group-by aliases and `similar()` — are unchanged. Added `testMalformedExpression`.

Prepared with AI assistance and reviewed before submission.