### PR TITLE
Fix LIMIT bind-parameter crashing content SQL search

### DIFF
--- a/src/python/txtai/embeddings/search/base.py
+++ b/src/python/txtai/embeddings/search/base.py
@@ -287,12 +287,12 @@ class Search:
         # Override limit with largest limit from database queries
         qlimit = 0
         for query in queries:
-            # Parse out qlimit
+            # Parse out qlimit; a non-numeric limit (e.g. a ":n" bind parameter) isn't a
+            # candidate-count override and must not be compared as a str against an int.
             l = query.get("limit")
-            if l and l.isdigit():
-                l = int(l)
+            l = int(l) if l and l.isdigit() else 0
 
-            qlimit = l if l and l > qlimit else qlimit
+            qlimit = l if l > qlimit else qlimit
 
         return qlimit
 

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -363,6 +363,21 @@ class TestEmbeddings(unittest.TestCase):
         uid = embeddings.search("feel good story", 1)[0][0]
         self.assertEqual(uid, 0)
 
+    def testLimitBindParameter(self):
+        """
+        Test a LIMIT bind parameter in a content SQL query
+        """
+
+        embeddings = Embeddings({"keyword": True, "content": True})
+        embeddings.index([(uid, text, None) for uid, text in enumerate(self.data)])
+
+        # A ":n" LIMIT bind parameter must not crash on the candidate-count parse (str vs int)
+        results = embeddings.search("select id from txtai order by id limit :n", parameters={"n": 2})
+        self.assertEqual(len(results), 2)
+
+        # A plain integer limit still works
+        self.assertEqual(len(embeddings.search("select id from txtai order by id limit 3")), 3)
+
     def testQuantize(self):
         """
         Test scalar quantization


### PR DESCRIPTION
`Search.limit` parses the candidate-count override with `if l and l.isdigit(): l = int(l)` and then `l if l and l > qlimit`. A `LIMIT` **bind parameter** (e.g. `select id from txtai order by id limit :n`) is a non-digit string, so `l` stays a `str` and `l > qlimit` compares `str` against `int`:

```
TypeError: '>' not supported between instances of 'str' and 'int'
```

This crashes **any** content-enabled SQL search that binds its LIMIT — `similar()` isn't required, and bind parameters are a documented feature.

```python
e.search("select id from txtai order by id limit :n", parameters={"n": 2})
# before: TypeError   after: 2 rows
```

Fix: treat a non-numeric limit as `0` for the candidate-count override; the `LIMIT :n` clause still flows through to SQLite with its bind parameter. Added `testLimitBindParameter` (keyword+content, offline).

Prepared with AI assistance and reviewed before submission.