### PR TITLE
Add milvus-lite embedded dense ANN backend

### DIFF
--- a/docs/embeddings/configuration/ann.md
+++ b/docs/embeddings/configuration/ann.md
@@ -4,7 +4,7 @@ Approximate Nearest Neighbor (ANN) index configuration for storing vector embedd
 
 ## backend
 ```yaml
-backend: faiss|hnsw|annoy|ggml|numpy|torch|turbovec|zvec|pgvector|sqlite|custom
+backend: faiss|hnsw|annoy|ggml|milvuslite|numpy|torch|turbovec|zvec|pgvector|sqlite|custom
 ```
 
 Sets the ANN backend. Defaults to `faiss`. Additional backends are available via the [ann](../../../install/#ann) extras package. Set custom backends via setting this parameter to the fully resolvable class string.

--- a/docs/embeddings/configuration/ann.md
+++ b/docs/embeddings/configuration/ann.md
@@ -4,7 +4,7 @@ Approximate Nearest Neighbor (ANN) index configuration for storing vector embedd
 
 ## backend
 ```yaml
-backend: faiss|hnsw|annoy|ggml|milvuslite|numpy|torch|turbovec|zvec|pgvector|sqlite|custom
+backend: faiss|hnsw|annoy|ggml|milvus|numpy|torch|turbovec|zvec|pgvector|sqlite|custom
 ```
 
 Sets the ANN backend. Defaults to `faiss`. Additional backends are available via the [ann](../../../install/#ann) extras package. Set custom backends via setting this parameter to the fully resolvable class string.

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ extras["ann"] = [
     "bitsandbytes>=0.42.0",
     "ggml-python>=0.0.41",
     "hnswlib>=0.5.0",
+    "milvus-lite>=3.1",
     "pgvector>=0.4.1",
     "scikit-learn>=0.23.1",
     "scipy>=1.4.1",

--- a/src/python/txtai/ann/dense/__init__.py
+++ b/src/python/txtai/ann/dense/__init__.py
@@ -6,7 +6,7 @@ from .annoy import Annoy
 from .factory import ANNFactory
 from .faiss import Faiss
 from .hnsw import HNSW
-from .milvuslite import MilvusLite
+from .milvus import Milvus
 from .numpy import NumPy
 from .pgvector import PGVector
 from .torch import Torch

--- a/src/python/txtai/ann/dense/__init__.py
+++ b/src/python/txtai/ann/dense/__init__.py
@@ -6,6 +6,7 @@ from .annoy import Annoy
 from .factory import ANNFactory
 from .faiss import Faiss
 from .hnsw import HNSW
+from .milvuslite import MilvusLite
 from .numpy import NumPy
 from .pgvector import PGVector
 from .torch import Torch

--- a/src/python/txtai/ann/dense/factory.py
+++ b/src/python/txtai/ann/dense/factory.py
@@ -8,6 +8,7 @@ from .annoy import Annoy
 from .faiss import Faiss, FAISS
 from .ggml import GGML
 from .hnsw import HNSW
+from .milvuslite import MilvusLite
 from .numpy import NumPy
 from .pgvector import PGVector
 from .sqlite import SQLite
@@ -44,6 +45,8 @@ class ANNFactory:
             ann = Faiss(config)
         elif backend == "hnsw":
             ann = HNSW(config)
+        elif backend == "milvuslite":
+            ann = MilvusLite(config)
         elif backend == "ggml":
             ann = GGML(config)
         elif backend == "numpy":

--- a/src/python/txtai/ann/dense/factory.py
+++ b/src/python/txtai/ann/dense/factory.py
@@ -8,7 +8,7 @@ from .annoy import Annoy
 from .faiss import Faiss, FAISS
 from .ggml import GGML
 from .hnsw import HNSW
-from .milvuslite import MilvusLite
+from .milvus import Milvus
 from .numpy import NumPy
 from .pgvector import PGVector
 from .sqlite import SQLite
@@ -45,8 +45,8 @@ class ANNFactory:
             ann = Faiss(config)
         elif backend == "hnsw":
             ann = HNSW(config)
-        elif backend == "milvuslite":
-            ann = MilvusLite(config)
+        elif backend == "milvus":
+            ann = Milvus(config)
         elif backend == "ggml":
             ann = GGML(config)
         elif backend == "numpy":

--- a/src/python/txtai/ann/dense/milvus.py
+++ b/src/python/txtai/ann/dense/milvus.py
@@ -10,15 +10,15 @@ import tempfile
 try:
     import milvus_lite
 
-    MILVUSLITE = True
+    MILVUS = True
 except ImportError:
-    MILVUSLITE = False
+    MILVUS = False
 
 from ...archive import ArchiveFactory
 from ..base import ANN
 
 
-class MilvusLite(ANN):
+class Milvus(ANN):
     """
     Builds an ANN index using the milvus-lite library.
     """
@@ -26,7 +26,7 @@ class MilvusLite(ANN):
     def __init__(self, config):
         super().__init__(config)
 
-        if not MILVUSLITE:
+        if not MILVUS:
             raise ImportError('milvus-lite is not available - install "ann" extra to enable')
 
         self.collection = None
@@ -73,7 +73,7 @@ class MilvusLite(ANN):
 
         # Add id offset and index build metadata
         self.config["offset"] = embeddings.shape[0]
-        self.metadata({"m": m, "milvuslite": milvus_lite.__version__})
+        self.metadata({"m": m, "milvus": milvus_lite.__version__})
 
     def append(self, embeddings):
         self.insert(embeddings, self.config["offset"])

--- a/src/python/txtai/ann/dense/milvuslite.py
+++ b/src/python/txtai/ann/dense/milvuslite.py
@@ -1,0 +1,138 @@
+"""
+milvus-lite module
+"""
+
+import os
+import shutil
+import tempfile
+
+# Conditional import
+try:
+    import milvus_lite
+
+    MILVUSLITE = True
+except ImportError:
+    MILVUSLITE = False
+
+from ...archive import ArchiveFactory
+from ..base import ANN
+
+
+class MilvusLite(ANN):
+    """
+    Builds an ANN index using the milvus-lite library.
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        if not MILVUSLITE:
+            raise ImportError('milvus-lite is not available - install "ann" extra to enable')
+
+        self.collection = None
+        self.directory = None
+        self.path = None
+
+    def load(self, path):
+        self.close()
+        self.directory = tempfile.mkdtemp()
+        self.path = os.path.join(self.directory, "index")
+
+        try:
+            archive = ArchiveFactory.create(self.directory)
+            archive.load(path, "tar")
+            self.open()
+        except Exception:
+            self.close()
+            raise
+
+    def index(self, embeddings):
+        self.close()
+
+        # Lookup index settings
+        m = self.setting("m", 50)
+
+        # Create collection
+        self.directory = tempfile.mkdtemp()
+        self.path = os.path.join(self.directory, "index")
+
+        # Use milvus-lite's native embedded API directly and keep this integration thin
+        self.backend = milvus_lite.MilvusLite(self.path)
+        schema = milvus_lite.CollectionSchema(
+            fields=[
+                milvus_lite.FieldSchema("id", milvus_lite.DataType.INT64, is_primary=True),
+                milvus_lite.FieldSchema("embedding", milvus_lite.DataType.FLOAT_VECTOR, dim=self.config["dimensions"]),
+            ]
+        )
+        self.collection = self.backend.create_collection("txtai", schema)
+        self.collection.create_index("embedding", {"index_type": "HNSW", "metric_type": "IP", "params": {"M": m}})
+        self.collection.load()
+
+        # Add items - position in embeddings is used as the id
+        self.insert(embeddings, 0)
+
+        # Add id offset and index build metadata
+        self.config["offset"] = embeddings.shape[0]
+        self.metadata({"m": m, "milvuslite": milvus_lite.__version__})
+
+    def append(self, embeddings):
+        self.insert(embeddings, self.config["offset"])
+
+        # Update id offset and index metadata
+        self.config["offset"] += embeddings.shape[0]
+        self.metadata()
+
+    def delete(self, ids):
+        if ids:
+            self.collection.delete(ids)
+
+    def search(self, queries, limit):
+        matches = self.collection.search(queries.tolist(), top_k=limit, metric_type="IP", anns_field="embedding")
+        return [[(int(match["id"]), float(match["distance"])) for match in results] for results in matches]
+
+    def count(self):
+        return self.collection.num_entities
+
+    def save(self, path):
+        self.collection.flush()
+        self.backend.close()
+        self.collection = None
+        self.backend = None
+        archive = ArchiveFactory.create(self.directory)
+        archive.save(path, "tar")
+        self.open()
+
+    def close(self):
+        # Release milvus-lite collection handles and the directory lock
+        if self.backend:
+            self.backend.close()
+        self.collection = None
+        super().close()
+
+        if self.directory and os.path.exists(self.directory):
+            shutil.rmtree(self.directory)
+
+        self.directory = None
+        self.path = None
+
+    def insert(self, embeddings, offset):
+        """
+        Inserts embeddings starting at offset.
+
+        Args:
+            embeddings: embeddings array
+            offset: starting id
+        """
+
+        if embeddings.shape[0]:
+            for start in range(0, embeddings.shape[0], 1024):
+                batch = embeddings[start : start + 1024]
+                self.collection.insert(
+                    [{"id": offset + start + uid, "embedding": embedding.tolist()} for uid, embedding in enumerate(batch)]
+                )
+
+    def open(self):
+        """Opens the milvus-lite database and collection."""
+
+        self.backend = milvus_lite.MilvusLite(self.path)
+        self.collection = self.backend.get_collection("txtai")

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -393,6 +393,25 @@ class TestDense(unittest.TestCase):
 
         self.runTests("turbovec")
 
+    def testMilvusLite(self):
+        """
+        Test milvus-lite backend
+        """
+
+        self.runTests("milvuslite")
+
+    def testMilvusLiteCustom(self):
+        """
+        Test milvus-lite backend with custom settings
+        """
+
+        self.runTests("milvuslite", {"milvuslite": {"m": 16}})
+
+        # Test invalid file path handled
+        with self.assertRaises(FileNotFoundError):
+            ann = ANNFactory.create({"backend": "milvuslite"})
+            ann.load("non-exist-path")
+
     def testZvec(self):
         """
         Test zvec backend

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -393,23 +393,23 @@ class TestDense(unittest.TestCase):
 
         self.runTests("turbovec")
 
-    def testMilvusLite(self):
+    def testMilvus(self):
         """
         Test milvus-lite backend
         """
 
-        self.runTests("milvuslite")
+        self.runTests("milvus")
 
-    def testMilvusLiteCustom(self):
+    def testMilvusCustom(self):
         """
         Test milvus-lite backend with custom settings
         """
 
-        self.runTests("milvuslite", {"milvuslite": {"m": 16}})
+        self.runTests("milvus", {"milvus": {"m": 16}})
 
         # Test invalid file path handled
         with self.assertRaises(FileNotFoundError):
-            ann = ANNFactory.create({"backend": "milvuslite"})
+            ann = ANNFactory.create({"backend": "milvus"})
             ann.load("non-exist-path")
 
     def testZvec(self):


### PR DESCRIPTION
Introduces a `milvus-lite` embedded ANN backend, following the thread in #1129 — separate PR, dense-only, mirroring the zvec backend's shape.

Credit to @zc277584121 for opening the lane in #1129 — this PR follows the maintainer's milvus-lite recommendation from that thread.

Scope per your recommendations there: depends on `milvus-lite` directly (no pymilvus), added to the `ann` extra in setup.py, pinned `>=3.1` — the 3.1.0 line is pure-Python, so the ubuntu/macos/windows CI matrix stays clean with no platform guards. Lifecycle matches zvec: close-before-reopen on load/index, save via ArchiveFactory, close() releases engine handles before removing temp state.

One trade-off stated up front: milvus-lite 3.x documents the native `MilvusLite` embedded API as its internal engine (their packaged public path is `pymilvus[milvus-lite]`). Using it directly matches your recommendation and keeps the dependency light; the backend is deliberately thin so any drift in a future minor is cheap to absorb — happy to own that maintenance.

Tests mirror testZvec/testZvecCustom: index/search round-trip, save/load, close/lock-release, and a custom-config case.
