### PR TITLE
Fix Segmentation dropping paragraph/section splits on CRLF line endings

### DIFF
--- a/src/python/txtai/pipeline/data/segmentation.py
+++ b/src/python/txtai/pipeline/data/segmentation.py
@@ -141,11 +141,11 @@ class Segmentation(Pipeline):
         elif self.sentences:
             content = [self.clean(x) for x in sent_tokenize(text)]
         elif self.lines:
-            content = [self.clean(x) for x in re.split(r"\n{1,}", text)]
+            content = [self.clean(x) for x in re.split(r"(?:\r?\n)+", text)]
         elif self.paragraphs:
-            content = [self.clean(x) for x in re.split(r"\n{2,}", text)]
+            content = [self.clean(x) for x in re.split(r"(?:\r?\n){2,}", text)]
         elif self.sections:
-            split = r"\f" if "\f" in text else r"\n{3,}"
+            split = r"\f" if "\f" in text else r"(?:\r?\n){3,}"
             content = [self.clean(x) for x in re.split(split, text)]
         else:
             content = self.clean(text)

--- a/test/python/testpipeline/testdata/testsegmentation.py
+++ b/test/python/testpipeline/testdata/testsegmentation.py
@@ -1,0 +1,40 @@
+"""
+Segmentation module tests
+"""
+
+import unittest
+
+from txtai.pipeline import Segmentation
+
+
+class TestSegmentation(unittest.TestCase):
+    """
+    Segmentation tests.
+    """
+
+    def testParagraphs(self):
+        """
+        Test paragraph segmentation with both LF and CRLF blank lines.
+        """
+        segment = Segmentation(paragraphs=True)
+        self.assertEqual(segment("Para A.\n\nPara B."), ["Para A.", "Para B."])
+        # Windows blank lines (\r\n\r\n) must split the same way as LF.
+        self.assertEqual(segment("Para A.\r\n\r\nPara B."), ["Para A.", "Para B."])
+
+    def testSections(self):
+        """
+        Test section segmentation with both LF and CRLF blank lines.
+        """
+        segment = Segmentation(sections=True)
+        self.assertEqual(segment("Sec A.\n\n\nSec B."), ["Sec A.", "Sec B."])
+        self.assertEqual(
+            segment("Sec A.\r\n\r\n\r\nSec B.\r\n\r\n\r\nSec C."),
+            ["Sec A.", "Sec B.", "Sec C."],
+        )
+
+    def testLines(self):
+        """
+        Test line segmentation tolerates CRLF.
+        """
+        segment = Segmentation(lines=True)
+        self.assertEqual(segment("Line A.\r\nLine B."), ["Line A.", "Line B."])


### PR DESCRIPTION
### What's broken

The `Segmentation` pipeline splits paragraphs/sections on `\n{2,}` / `\n{3,}`, which require *consecutive* newline characters:

```python
elif self.paragraphs:
    content = [self.clean(x) for x in re.split(r"\n{2,}", text)]
elif self.sections:
    split = r"\f" if "\f" in text else r"\n{3,}"
```

A Windows/HTTP blank line is `\r\n\r\n`, whose `\n`s are separated by `\r`, so the quantifier never matches and the whole document collapses into a **single** chunk:

```python
Segmentation(sections=True)("Sec A.\r\n\r\n\r\nSec B.\r\n\r\n\r\nSec C.")
# ['Sec A.\r\n\r\n\r\nSec B.\r\n\r\n\r\nSec C.']   -- expected 3 sections
```

Notably `lines` mode already tolerates CRLF (its `\r` is stripped by `clean()`), so the class handled line endings **inconsistently across its own modes** — strong evidence this is a bug, not an LF-only contract.

### Fix

Change the newline splits to `(?:\r?\n){N,}`. Pure-LF input matches identically (behavior preserved), and a single soft `\r\n` inside a paragraph is still kept together.

### Tests

Adds `test/python/testpipeline/testdata/testsegmentation.py` (the pipeline had no test module) covering paragraphs/sections/lines with both LF and CRLF. All pass.