### PR TITLE
Fix IVFSparse returning unsorted sparse ANN search results

### DIFF
--- a/src/python/txtai/ann/sparse/ivfsparse.py
+++ b/src/python/txtai/ann/sparse/ivfsparse.py
@@ -273,6 +273,10 @@ class IVFSparse(ANN):
         indices = np.argpartition(-scores, limit if limit < scores.shape[1] else scores.shape[1] - 1)[:, :limit]
         scores = np.take_along_axis(scores, indices, axis=1)
 
+        # argpartition doesn't order within the top n - sort each row by score descending
+        order = np.argsort(-scores, axis=1)
+        indices, scores = np.take_along_axis(indices, order, axis=1), np.take_along_axis(scores, order, axis=1)
+
         return indices, scores
 
     def scan(self, query, limit, blockids):

--- a/src/python/txtai/pipeline/text/lateencoder.py
+++ b/src/python/txtai/pipeline/text/lateencoder.py
@@ -100,6 +100,10 @@ class LateEncoder(Pipeline):
         indices = np.argpartition(-scores, limit if limit and limit < scores.shape[0] else scores.shape[0] - 1)[:, :limit]
         scores = np.take_along_axis(scores, indices, axis=1)
 
+        # argpartition doesn't order within the top n - sort each row by score descending
+        order = np.argsort(-scores, axis=1)
+        indices, scores = np.take_along_axis(indices, order, axis=1), np.take_along_axis(scores, order, axis=1)
+
         results = []
         for x, index in enumerate(indices):
             results.append(list(zip(index.tolist(), scores[x].tolist())))

--- a/test/python/testann/testsparse.py
+++ b/test/python/testann/testsparse.py
@@ -105,6 +105,24 @@ class TestSparse(unittest.TestCase):
 
         ann.close()
 
+    def testIVFSparseSortOrder(self):
+        """
+        Test IVFSparse returns results sorted by score descending
+        """
+
+        # Generate test data
+        data = self.generate(50, 30522)
+
+        ann = SparseANNFactory.create({"backend": "ivfsparse"})
+        ann.index(data)
+
+        # Each result list must be ranked by score descending
+        for results in ann.search(data[:5], 10):
+            scores = [score for _, score in results]
+            self.assertEqual(scores, sorted(scores, reverse=True))
+
+        ann.close()
+
     @patch("sqlalchemy.orm.Query.limit")
     def testPGSparse(self, query):
         """


### PR DESCRIPTION
IVFSparse (the default sparse ANN backend) returns its top-n results in arbitrary order. `IVFSparse.topn` selects the top n with `np.argpartition` but never sorts them, so `search()` results are not ranked by score descending — unlike every other backend (numpy `argsort`, hnsw/faiss, sqlite `ORDER BY distance`, pgvector).

Repro (numpy/scipy/scikit-learn only):

```python
import numpy as np
from scipy.sparse import csr_matrix
from txtai.ann import SparseANNFactory

d = np.array([[1,0,0,0],[0.9,0.1,0,0],[0.8,0.2,0,0],[0.7,0.3,0,0]], dtype=np.float32)
d = d / np.linalg.norm(d, axis=1, keepdims=True)
ann = SparseANNFactory.create({"backend": "ivfsparse", "dimensions": 4})
ann.index(csr_matrix(d))
print(ann.search(csr_matrix(d[0]), 4)[0])
# before: [(1, 0.994), (0, 1.0), (2, 0.97), (3, 0.919)]   <- id 0 (score 1.0) not first
# after:  [(0, 1.0), (1, 0.994), (2, 0.97), (3, 0.919)]
```

Fix: sort each row by score descending after the `argpartition`. The `LateEncoder` pipeline builds its ranked results with the same `argpartition`-without-sort pattern and is fixed the same way.

Added `testIVFSparseSortOrder`, which asserts search results are score-sorted; it fails before the change and passes after.