### PR TITLE
Fix HNSW search RuntimeError when limit exceeds indexed element count

### DIFF
--- a/src/python/txtai/ann/dense/hnsw.py
+++ b/src/python/txtai/ann/dense/hnsw.py
@@ -85,8 +85,8 @@ class HNSW(ANN):
         if ef:
             self.backend.set_ef(ef)
 
-        # Run the query
-        ids, distances = self.backend.knn_query(queries, k=limit)
+        # Run the query, clamp k to the current element count as hnswlib errors when k exceeds it
+        ids, distances = self.backend.knn_query(queries, k=min(limit, self.count()))
 
         # Map results to [(id, score)]
         results = []

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -196,6 +196,21 @@ class TestDense(unittest.TestCase):
         # Test with custom settings
         self.runTests("hnsw", {"hnsw": {"efconstruction": 100, "m": 4, "randomseed": 0, "efsearch": 5}})
 
+    def testHnswSearchLimitExceedsCount(self):
+        """
+        Test Hnswlib backend search when limit exceeds the indexed element count
+        """
+
+        data = np.random.rand(3, 240).astype(np.float32)
+        self.normalize(data)
+
+        ann = ANNFactory.create({"backend": "hnsw", "dimensions": 240})
+        ann.index(data)
+
+        # Query limit (10) exceeds the number of indexed elements (3), previously raised a RuntimeError
+        results = ann.search(data[0:1], 10)
+        self.assertEqual(len(results[0]), 3)
+
     @unittest.skipIf(os.name == "nt", "Skip Milvus on Windows")
     def testMilvus(self):
         """


### PR DESCRIPTION
## Root cause

`HNSW.search` (`src/python/txtai/ann/dense/hnsw.py`) passes the raw `limit` straight through as `k` to hnswlib's `knn_query`:

```python
ids, distances = self.backend.knn_query(queries, k=limit)
```

hnswlib raises when `k` exceeds the number of elements currently in the index. Every other dense backend already tolerates `limit > count`: faiss pads with `-1`, annoy tolerates `n > items`, and the SQL-backed backends apply `LIMIT`. HNSW is the only one that crashes.

## Fix

Clamp `k` to `min(limit, self.count())` before calling `knn_query`. `self.count()` is the same accessor the backend already exposes (`get_current_count() - deletes`), so this keeps deletes correctly out of the clamp.

## Test

Added `testHnswSearchLimitExceedsCount`, which indexes 3 vectors and searches with `limit=10`. Fails on main with `RuntimeError: Cannot return the results in a contiguous 2D array. Probably ef or M is too small`, passes on this branch.

## Verified

Docker (`python:3.12-slim`, `pip install -e .` plus `hnswlib`/`numpy`/`sqlalchemy`), differential main vs. this branch, `module.__file__` provenance checked on both sides. Ran the full `testann.testdense` suite on this branch: the three HNSW tests (`testHnsw`, `testHnswCustom`, `testHnswSearchLimitExceedsCount`) pass; the other 37 failures in that run are pre-existing `ModuleNotFoundError`s from backends I did not install locally (annoy, ggml, milvus, torch, fastapi, etc.), unrelated to this change. `black --check` and `pylint` (10.00/10) both pass on the two changed files.

Fixes #1158
