### PR TITLE
Fix Scoring.delete() crashing on ids that were never indexed

### DIFF
--- a/src/python/txtai/scoring/terms.py
+++ b/src/python/txtai/scoring/terms.py
@@ -129,8 +129,8 @@ class Terms:
             ids: ids to delete
         """
 
-        # Set index ids as deleted
-        self.deletes.extend([self.ids.index(i) for i in ids])
+        # Set index ids as deleted, ignore ids that were never indexed
+        self.deletes.extend([self.ids.index(i) for i in ids if i in self.ids])
 
     def index(self):
         """

--- a/src/python/txtai/scoring/tfidf.py
+++ b/src/python/txtai/scoring/tfidf.py
@@ -95,10 +95,10 @@ class TFIDF(Scoring):
         if self.terms:
             self.terms.delete(ids)
 
-        # Delete content
+        # Delete content, ignore ids that were never indexed
         if self.documents:
             for uid in ids:
-                self.documents.pop(uid)
+                self.documents.pop(uid, None)
 
     def index(self, documents=None):
         # Call base method

--- a/test/python/testscoring/testkeyword.py
+++ b/test/python/testscoring/testkeyword.py
@@ -147,6 +147,25 @@ class TestKeyword(unittest.TestCase):
         self.assertEqual(scoring.count(), 0)
         self.assertEqual(scoring.search("bear", 1), [])
 
+    def testDeleteUnknownId(self):
+        """
+        Test that deleting an id that was never indexed is a no-op, not a crash
+        """
+
+        # Terms index (bm25): Terms.delete used self.ids.index(), raising ValueError
+        scoring = ScoringFactory.create({"method": "bm25", "terms": True, "content": True})
+        scoring.index(self.data)
+
+        scoring.delete([0, len(self.data) + 100])
+        self.assertFalse(scoring.search("tops", 1))
+
+        # TFIDF content only, terms disabled: TFIDF.delete used dict.pop(), raising KeyError
+        scoring = ScoringFactory.create({"method": "tfidf", "content": True})
+        scoring.index(self.data)
+
+        scoring.delete([0, len(self.data) + 100])
+        self.assertNotIn(0, scoring.documents)
+
     def testTFIDF(self):
         """
         Test tfidf


### PR DESCRIPTION
## Root cause

`Terms.delete()` (`src/python/txtai/scoring/terms.py`) and `TFIDF.delete()`
(`src/python/txtai/scoring/tfidf.py`) both assume every id passed in is already
indexed:

```python
# terms.py
self.deletes.extend([self.ids.index(i) for i in ids])

# tfidf.py
for uid in ids:
    self.documents.pop(uid)
```

`list.index()` raises `ValueError` and `dict.pop()` raises `KeyError` the moment
an id was never indexed, e.g. a document whose only field was `object` (a
supported input per `docs/embeddings/query.md`) is silently dropped by
`insert()` but still gets passed to `delete()` later. Every other scoring/ANN
backend treats a delete on an absent id as a no-op (`ann/dense/numpy.py`
pre-filters before deleting, `pgtext.py`'s SQL `DELETE ... WHERE ... IN` simply
matches zero rows), so this is an inconsistency between backends rather than
an intentional contract.

## Fix

Guard both lookups: skip ids not in `self.ids` in `Terms.delete()`, and use
`dict.pop(uid, None)` in `TFIDF.delete()`. Both now match the no-op behavior
the other backends already have.

## Tests

Added `testDeleteUnknownId` to `test/python/testscoring/testkeyword.py`,
covering both the BM25/terms path and the TFIDF content-only path. It fails on
main (`ValueError: ... is not in list` / `KeyError`) and passes on this
branch.

## Verified

- `testDeleteUnknownId` fails on main, passes on this branch (Docker,
  `python:3.12-slim`, differential with `module.__file__` provenance checked
  on both sides).
- `test/python/testscoring/testkeyword.py`: 9/10 pass on both main and this
  branch; the 10th (`testPGText`) errors on `ModuleNotFoundError: sqlalchemy`
  on both sides alike, unrelated to this change.
- `black --check` and `pylint` (10.00/10, repo's own `.pylintrc`) on the
  changed files.
- Did not run the full `make data coverage` matrix (needs the full `[all,dev]`
  extras and downloaded test fixtures); scoped verification to the changed
  module and its test file.
