### PR TITLE
Add LEMUR fixed dimensional encoding

### DIFF
--- a/docs/embeddings/configuration/vectors.md
+++ b/docs/embeddings/configuration/vectors.md
@@ -155,6 +155,18 @@ muvera:
 
 Settings to control the size of MUVERA fixed dimensional outputs. Default is 20 * 2^5 * 16 = 10,240 dimensions.
 
+### lemur
+```yaml
+lemur:
+    path: local artifact directory or Hugging Face Hub path
+```
+
+Loads a trained [LEMUR](../../../pipeline/train/lemur) fixed dimensional encoder. LEMUR artifacts are corpus-specific and must be
+created with `LemurTrainer` before configuring an embeddings index. Query vectors are summed learned features and document vectors
+are ordinary least squares weights over the artifact's stored token sample. Each artifact contains `config.json` and
+`model.safetensors`; the Safetensors file contains inference state only. See the trainer page for score filtering and Faiss exact/IVF
+search behavior.
+
 ### trust_remote_code
 ```yaml
 trust_remote_code: boolean

--- a/docs/pipeline/train/lemur.md
+++ b/docs/pipeline/train/lemur.md
@@ -1,0 +1,82 @@
+# LemurTrainer
+
+![pipeline](../../images/pipeline.png#only-light)
+![pipeline](../../images/pipeline-dark.png#only-dark)
+
+Trains a LEMUR fixed dimensional encoder for a late interaction model and corpus. Training is a separate pipeline step; the saved
+artifact is then loaded through the embeddings `vectors.lemur` configuration.
+
+## Example
+
+```python
+from txtai.pipeline import LemurTrainer
+
+corpus = [
+    "First document",
+    "Second document",
+    "Third document",
+]
+
+trainer = LemurTrainer()
+trainer(
+    "colbert-ir/colbertv2.0",
+    corpus,
+    "lemur-model",
+    epochs=100,
+    validation_split=0.1,
+)
+```
+
+`epochs` is required so the training mode is explicit. Use `epochs=100` for the quality-oriented MLP setting. This can take hours on
+a CPU. Use `epochs=0` to select deterministic random ELM features as a lower-cost fallback.
+
+The learn distribution defaults to `learn_category="query"`. Target documents are always encoded with the data encoder, so the
+default encodes selected corpus texts once as data and once as queries. Set `learn_category="data"` to reuse the data encodings, or
+pass a separate iterable of texts with `learn`.
+
+Set `corpus_subset_size` to a positive integer to sample that many raw corpus texts under `seed` before either encoding pass. The
+default is `None`, which uses every corpus text. `train_subset_size` and `learn_subset_size` apply later, after token vectors have
+already been created. `corpus_subset_size` applies to `data`; a separate `learn` iterable remains caller-sized.
+
+For trained MLP features, set `validation_split` to a fraction greater than zero and less than one to retain the epoch with the lowest
+held-out loss. The default is `0.0`, which preserves training-loss selection. The selected one-based epoch, loss and metric are
+available as `selected_epoch`, `selected_loss` and `selection_metric` on the fitted or reloaded encoder.
+
+The artifact contains `config.json` and `model.safetensors`. It stores the inference feature model, output-normalization statistics
+and token sample needed to encode documents added after training. The training-only output readout is not saved.
+
+Load the artifact in an embeddings configuration.
+
+```yaml
+embeddings:
+    path: colbert-ir/colbertv2.0
+    vectors:
+        lemur:
+            path: lemur-model
+```
+
+## Search behavior
+
+LEMUR approximates standardized MaxSim targets, so useful ranking scores can be negative. txtai's dense vector path L2-normalizes the
+fixed vectors and removes results with scores less than or equal to zero. This can change ordering and return fewer than the requested
+number of candidates compared with raw maximum inner-product search.
+
+The Faiss backend uses exact `IDMap,Flat` search through 5,000 rows and switches to an IVF index above that threshold. In the measured
+scifact run, default IVF reduced LEMUR NDCG@10 by 43% relative to exact search, compared with 25% for MUVERA. For LEMUR corpora above
+5,000 rows, either pin `faiss.components` to an exact index or tune the IVF settings for the corpus. The exact configuration is:
+
+```yaml
+embeddings:
+    path: colbert-ir/colbertv2.0
+    vectors:
+        lemur:
+            path: lemur-model
+    faiss:
+        components: IDMap,Flat
+```
+
+## Methods
+
+Python documentation for the pipeline.
+
+### ::: txtai.pipeline.LemurTrainer.__call__

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
             - Translation: pipeline/text/translation.md
         - Train:
             - HF ONNX: pipeline/train/hfonnx.md
+            - LEMUR Trainer: pipeline/train/lemur.md
             - ML ONNX: pipeline/train/mlonnx.md
             - Trainer: pipeline/train/trainer.md
     - Workflow:

--- a/src/python/txtai/models/pooling/__init__.py
+++ b/src/python/txtai/models/pooling/__init__.py
@@ -7,4 +7,5 @@ from .cls import ClsPooling
 from .factory import PoolingFactory
 from .last import LastPooling
 from .late import LatePooling
+from .lemur import Lemur
 from .mean import MeanPooling

--- a/src/python/txtai/models/pooling/late.py
+++ b/src/python/txtai/models/pooling/late.py
@@ -3,6 +3,7 @@ Late module
 """
 
 from .base import Pooling
+from .lemur import Lemur
 from .muvera import Muvera
 
 # Core library imports
@@ -24,10 +25,14 @@ class LatePooling(Pooling):
         # Check if fixed dimensional encoder is enabled
         modelargs = modelargs.copy() if modelargs else {}
         muvera = modelargs.pop("muvera", {})
-        self.encoder = Muvera(**muvera) if muvera is not None else None
+        lemur = modelargs.pop("lemur", None)
 
         # Call parent initialization
         super().__init__(path, device, tokenizer, maxlength, loadprompts, modelargs)
+
+        # Create fixed dimensional encoder
+        self.encoder = Lemur(device=self.device, **lemur) if lemur is not None else Muvera(**muvera) if muvera is not None else None
+        self.lengths = None
 
         # Get linear weights paths
         config = self.load(path, "modules.json")
@@ -55,6 +60,10 @@ class LatePooling(Pooling):
             Late pooled embeddings using output token embeddings (i.e. last hidden state)
         """
 
+        # Track true token counts for encoders that can't consume padding
+        if getattr(self.encoder, "unpadded", False):
+            self.lengths.extend(inputs["attention_mask"].sum(dim=1).cpu().tolist())
+
         # Run through transformers model
         tokens = super().forward(**inputs)
 
@@ -69,6 +78,10 @@ class LatePooling(Pooling):
             documents: list of documents used to build embeddings
             category: embeddings category (query or data)
         """
+
+        # Reset true token counts for this encoding pass
+        if getattr(self.encoder, "unpadded", False):
+            self.lengths = []
 
         results = []
 
@@ -97,6 +110,16 @@ class LatePooling(Pooling):
         Returns:
             normalized results with padding
         """
+
+        # LEMUR operates on normalized true token rows before batch padding
+        if getattr(self.encoder, "unpadded", False):
+            data = []
+            for vectors, length in zip(results, self.lengths):
+                vectors = vectors[:length]
+                vectors /= np.linalg.norm(vectors, axis=1)[:, np.newaxis]
+                data.append(vectors)
+
+            return self.encoder(data, category)
 
         length = 0
         for vectors in results:

--- a/src/python/txtai/models/pooling/lemur.py
+++ b/src/python/txtai/models/pooling/lemur.py
@@ -1,0 +1,681 @@
+"""
+LEMUR module
+"""
+
+import json
+import math
+import os
+
+# Core library imports
+from ...util import Download, Library
+
+library = Library()
+np = library.numpy()
+safetensors = library.safetensors()
+torch = library.torch()
+Module = library.module()
+
+
+class Lemur:
+    """
+    Implements the LEMUR (Learned Multi-Vector Retrieval) algorithm. This reduces
+    late interaction multi-vector outputs to a single fixed vector.
+
+    LEMUR artifacts contain a feature encoder, output normalization statistics and
+    a sample of learn-token vectors used to solve document weights. Query vectors
+    are summed feature encodings while document vectors are ordinary least squares
+    weights over the stored sample.
+
+    This code is based on the following:
+      - Paper: https://arxiv.org/abs/2601.21853
+      - GitHub: https://github.com/ejaasaari/lemur
+    """
+
+    # Signals LatePooling that this encoder must receive true, unpadded token rows
+    unpadded = True
+
+    def __init__(self, path=None, device=None):
+        """
+        Creates a LEMUR encoder.
+
+        Args:
+            path: local artifact directory or Hugging Face Hub path
+            device: tensor device
+        """
+
+        self.device = torch.device(device) if device is not None else torch.device("cpu")
+        self.model = None
+        self.sample = None
+        self.mean = None
+        self.std = None
+        self.config = None
+        self.pinv = None
+        self.selected_epoch = None
+        self.selected_loss = None
+        self.selection_metric = None
+
+        if path:
+            self.load(path)
+
+    def __call__(self, data, category):
+        """
+        Transforms multi-vector collections into fixed dimensional vectors.
+
+        Args:
+            data: list or array of unpadded multi-vector collections
+            category: embeddings category (query or data)
+
+        Returns:
+            fixed dimensional vectors
+        """
+
+        if category == "query":
+            vectors = self.compute_features(data)
+        elif category == "data":
+            vectors = self.compute_weights(data)
+        else:
+            raise ValueError("category must be query or data")
+
+        return vectors.detach().cpu().to(torch.float32).numpy()
+
+    # pylint: disable=R0913,R0917
+    def fit(
+        self,
+        data,
+        output=None,
+        train_subset_size=8192,
+        learn_subset_size=100000,
+        ols_sample_size=16384,
+        num_layers=1,
+        hidden_dim=512,
+        final_hidden_dim=2048,
+        activation="gelu",
+        epochs=None,
+        lr=3e-3,
+        batch_size=512,
+        grad_clip=0.5,
+        query_scale=32,
+        seed=42,
+        validation_split=0.0,
+        learn=None,
+    ):
+        """
+        Fits a LEMUR feature encoder and OLS sample.
+
+        Args:
+            data: iterable of unpadded corpus token-vector arrays
+            output: optional artifact output directory
+            train_subset_size: maximum number of documents used to build targets
+            learn_subset_size: maximum number of token vectors used to learn features
+            ols_sample_size: maximum number of token vectors stored for document weights
+            num_layers: number of MLP feature layers
+            hidden_dim: MLP hidden dimension
+            final_hidden_dim: fixed output dimension
+            activation: feature activation
+            epochs: required training choice; 100 is the quality MLP setting and 0 selects deterministic ELM features
+            lr: Adam learning rate
+            batch_size: training batch size
+            grad_clip: optional gradient clipping value
+            query_scale: query feature sum scale
+            seed: random seed
+            validation_split: fraction of sampled learn tokens held out for validation
+            learn: optional iterable of learn-token arrays, defaults to data
+
+        Returns:
+            self
+        """
+
+        if epochs is None:
+            raise ValueError("epochs must be set explicitly: use epochs=100 for trained MLP quality or epochs=0 for deterministic ELM features")
+        if epochs < 0:
+            raise ValueError("epochs must be greater than or equal to 0")
+        for name, value in [
+            ("ols_sample_size", ols_sample_size),
+            ("query_scale", query_scale),
+            ("num_layers", num_layers),
+            ("batch_size", batch_size),
+            ("train_subset_size", train_subset_size),
+            ("learn_subset_size", learn_subset_size),
+        ]:
+            if value <= 0:
+                raise ValueError(f"{name} must be greater than 0")
+        if final_hidden_dim < 1:
+            raise ValueError("final_hidden_dim must be greater than 0")
+        if validation_split < 0 or validation_split >= 1:
+            raise ValueError("validation_split must be greater than or equal to 0 and less than 1")
+
+        self.selected_epoch = None
+        self.selected_loss = None
+        self.selection_metric = None
+
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(seed)
+        training = self._create_training_data(
+            data,
+            learn,
+            (train_subset_size, learn_subset_size),
+            validation_split,
+            generator,
+        )
+
+        model_type = "elm" if epochs == 0 else "mlp"
+        config = {
+            "model_type": model_type,
+            "input_dim": training["dimension"],
+            "hidden_dim": hidden_dim,
+            "final_hidden_dim": final_hidden_dim,
+            "num_layers": num_layers,
+            "activation": activation,
+            "query_scale": query_scale,
+            "seed": seed,
+        }
+
+        # Isolate seeded model construction from the caller's global RNG state
+        with torch.random.fork_rng():
+            torch.manual_seed(seed)
+            self.model = LemurModel(output_dim=training["train_size"], **config).to(self.device)
+
+        if epochs:
+            self.train(
+                training["inputs"],
+                training["targets"],
+                epochs,
+                lr,
+                batch_size,
+                grad_clip,
+                seed,
+                training["validation_inputs"],
+                training["validation_targets"],
+            )
+            config["training"] = {
+                "selected_epoch": self.selected_epoch,
+                "selected_loss": self.selected_loss,
+                "selection_metric": self.selection_metric,
+                "validation_split": validation_split,
+            }
+
+        # Persist the exact learn-token sample used by future document upserts
+        learn_tokens = training["learn"]
+        sample_size = min(ols_sample_size, len(learn_tokens))
+        sample_indices = torch.randperm(len(learn_tokens), generator=generator)[:sample_size].to(learn_tokens.device)
+        self.sample = learn_tokens[sample_indices].detach()
+        self.config = config
+        self.pinv = None
+
+        if output:
+            self.save(output)
+
+        return self
+
+    def _create_training_data(self, data, learn, subset_sizes, validation_split, generator):
+        """
+        Creates sampled training and optional validation data.
+
+        Args:
+            data: iterable of unpadded corpus token-vector arrays
+            learn: optional iterable of learn-token arrays
+            subset_sizes: train-document and learn-token sample limits
+            validation_split: fraction of sampled learn tokens held out for validation
+            generator: seeded random generator
+
+        Returns:
+            sampled training data
+        """
+
+        documents = self.documents(data)
+        if not documents:
+            raise ValueError("data must contain at least one document")
+
+        dimension = documents[0].shape[1]
+        if any(document.shape[1] != dimension for document in documents):
+            raise ValueError("all token vectors must have the same dimension")
+
+        learn_documents = documents if learn is None else self.documents(learn)
+        if not learn_documents:
+            raise ValueError("learn must contain at least one document")
+        if any(document.shape[1] != dimension for document in learn_documents):
+            raise ValueError("all learn token vectors must match the data dimension")
+
+        train_subset_size, learn_subset_size = subset_sizes
+        train_size = min(train_subset_size, len(documents))
+        train_indices = torch.randperm(len(documents), generator=generator)[:train_size].tolist()
+        train = [documents[index] for index in train_indices]
+
+        tokens = torch.cat(learn_documents)
+        learn_size = min(learn_subset_size, len(tokens))
+        learn_indices = torch.randperm(len(tokens), generator=generator)[:learn_size].to(tokens.device)
+        learn_tokens = tokens[learn_indices]
+
+        inputs, validation_inputs = learn_tokens, None
+        if validation_split:
+            validation_size = max(1, int(len(learn_tokens) * validation_split))
+            if validation_size >= len(learn_tokens):
+                raise ValueError("validation_split must leave at least one learn token for training")
+
+            validation_inputs = learn_tokens[:validation_size]
+            inputs = learn_tokens[validation_size:]
+
+        targets = self.maxsim(train, inputs)
+        self.mean = targets.mean()
+        self.std = targets.std(unbiased=False)
+        if not torch.isfinite(self.std) or self.std <= torch.finfo(targets.dtype).eps:
+            raise ValueError("LEMUR targets have zero variance")
+
+        targets = (targets - self.mean) / self.std
+        validation_targets = None
+        if validation_inputs is not None:
+            validation_targets = (self.maxsim(train, validation_inputs) - self.mean) / self.std
+
+        return {
+            "dimension": dimension,
+            "train_size": train_size,
+            "learn": learn_tokens,
+            "inputs": inputs,
+            "targets": targets,
+            "validation_inputs": validation_inputs,
+            "validation_targets": validation_targets,
+        }
+
+    def train(
+        self,
+        inputs,
+        targets,
+        epochs,
+        lr,
+        batch_size,
+        grad_clip,
+        seed,
+        validation_inputs=None,
+        validation_targets=None,
+    ):
+        """
+        Trains the MLP feature extractor and temporary readout layer.
+
+        Args:
+            inputs: learn-token vectors
+            targets: standardized maxsim targets
+            epochs: number of training epochs
+            lr: Adam learning rate
+            batch_size: training batch size
+            grad_clip: optional gradient clipping value
+            seed: random seed
+            validation_inputs: optional held-out learn-token vectors
+            validation_targets: optional standardized validation targets
+        """
+
+        inputs, targets = inputs.to(self.device), targets.to(self.device)
+        if validation_inputs is not None:
+            validation_inputs = validation_inputs.to(self.device)
+            validation_targets = validation_targets.to(self.device)
+
+        optimizer = torch.optim.Adam(self.model.parameters(), lr=lr)
+        lossfn = torch.nn.MSELoss()
+        generator = torch.Generator(device="cpu")
+        generator.manual_seed(seed)
+        best, state = float("inf"), None
+
+        for epoch in range(epochs):
+            self.model.train()
+            indices = torch.randperm(len(inputs), generator=generator)
+            total, batches = 0.0, 0
+
+            for start in range(0, len(inputs), batch_size):
+                batch = indices[start : start + batch_size].to(inputs.device)
+                optimizer.zero_grad(set_to_none=True)
+                loss = lossfn(self.model(inputs[batch]), targets[batch])
+                loss.backward()
+
+                if grad_clip is not None and grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), grad_clip)
+
+                optimizer.step()
+                total += loss.detach().item()
+                batches += 1
+
+            score = total / batches
+            metric = score
+            selection_metric = "training_loss"
+            if validation_inputs is not None:
+                self.model.eval()
+                with torch.inference_mode():
+                    metric = lossfn(self.model(validation_inputs), validation_targets).item()
+                selection_metric = "validation_loss"
+
+            if metric < best:
+                best = metric
+                state = {name: value.detach().cpu().clone() for name, value in self.model.state_dict().items()}
+                self.selected_epoch = epoch + 1
+                self.selected_loss = metric
+                self.selection_metric = selection_metric
+
+        if state:
+            self.model.load_state_dict(state)
+
+    def compute_features(self, data):
+        """
+        Computes summed query features.
+
+        Args:
+            data: list or array of unpadded query token-vector collections
+
+        Returns:
+            fixed dimensional query features
+        """
+
+        self.check()
+        documents = self.documents(data)
+        self.model.eval()
+
+        with torch.inference_mode():
+            return torch.stack([self.model.features(document).sum(dim=0) / self.config["query_scale"] for document in documents])
+
+    def compute_weights(self, data):
+        """
+        Computes ordinary least squares document weights.
+
+        Args:
+            data: list or array of unpadded document token-vector collections
+
+        Returns:
+            fixed dimensional document weights
+        """
+
+        self.check()
+        documents = self.documents(data)
+
+        # Precompute the feature sample SVD once per loaded encoder
+        if self.pinv is None:
+            self.model.eval()
+            with torch.inference_mode():
+                features = self.model.features(self.sample)
+                left, values, right = torch.linalg.svd(features, full_matrices=False)
+                tolerance = torch.finfo(values.dtype).eps * max(features.shape) * values.max()
+                scales = torch.where(values > tolerance, values.reciprocal(), torch.zeros_like(values))
+                self.pinv = (right.T * scales) @ left.T
+
+        targets = (self.maxsim(documents, self.sample) - self.mean) / self.std
+        return (self.pinv @ targets).T
+
+    def documents(self, data):
+        """
+        Converts input data to a list of float32 tensors.
+
+        Args:
+            data: list or array of multi-vector collections
+
+        Returns:
+            list of tensors
+        """
+
+        if isinstance(data, np.ndarray):
+            if data.ndim == 2:
+                data = [data]
+            elif data.ndim == 3:
+                data = list(data)
+
+        documents = []
+        for document in data:
+            if isinstance(document, np.ndarray):
+                document = torch.from_numpy(document)
+            elif torch.is_tensor(document):
+                document = document.detach()
+            else:
+                document = torch.tensor(document)
+
+            if document.ndim != 2 or document.shape[0] == 0:
+                raise ValueError("each document must be a non-empty 2D token-vector array")
+
+            documents.append(document.to(device=self.device, dtype=torch.float32))
+
+        return documents
+
+    @staticmethod
+    def maxsim(documents, queries):
+        """
+        Computes single-token maxsim targets.
+
+        Args:
+            documents: list of document token-vector tensors
+            queries: token vectors used as independent single-token queries
+
+        Returns:
+            matrix with a row per query token and column per document
+        """
+
+        return torch.stack([(queries @ document.T).max(dim=1).values for document in documents], dim=1)
+
+    def save(self, path):
+        """
+        Saves LEMUR artifacts.
+
+        Args:
+            path: output artifact directory
+        """
+
+        self.check()
+        os.makedirs(path, exist_ok=True)
+
+        with open(os.path.join(path, "config.json"), "w", encoding="utf-8") as output:
+            json.dump(self.config, output, indent=2, sort_keys=True)
+            output.write("\n")
+
+        tensors = {name: value.detach().cpu().contiguous() for name, value in self.model.state_dict().items() if not name.startswith("output_layer.")}
+        tensors.update(
+            {
+                "lemur.mean": self.mean.detach().cpu().reshape(1),
+                "lemur.std": self.std.detach().cpu().reshape(1),
+                "lemur.sample": self.sample.detach().cpu().contiguous(),
+            }
+        )
+        safetensors.torch.save_file(tensors, os.path.join(path, "model.safetensors"))
+
+    def load(self, path):
+        """
+        Loads LEMUR artifacts from a local directory or Hugging Face Hub path.
+
+        Args:
+            path: local artifact directory or Hugging Face Hub path
+        """
+
+        config = Download()(path, "config.json")
+        weights = Download()(path, "model.safetensors")
+
+        with open(config, encoding="utf-8") as source:
+            self.config = json.load(source)
+
+        self.model = LemurModel(**self.config).to(self.device)
+        training = self.config.get("training", {})
+        self.selected_epoch = training.get("selected_epoch")
+        self.selected_loss = training.get("selected_loss")
+        self.selection_metric = training.get("selection_metric")
+        with safetensors.safe_open(weights, framework="pt", device=str(self.device)) as source:
+            tensors = {name: source.get_tensor(name) for name in source.keys()}
+
+        self.mean = tensors.pop("lemur.mean")[0]
+        self.std = tensors.pop("lemur.std")[0]
+        self.sample = tensors.pop("lemur.sample")
+        self.model.load_state_dict(tensors)
+        self.model.eval()
+        self.pinv = None
+
+        return self
+
+    def check(self):
+        """
+        Validates that fitted or loaded LEMUR state is available.
+        """
+
+        if self.model is None or self.sample is None or self.mean is None or self.std is None:
+            raise ValueError("LEMUR must be fitted or loaded before encoding")
+
+
+class LemurModel(Module):
+    """
+    LEMUR feature extractor with an optional training-only linear readout.
+    """
+
+    # pylint: disable=R0913,R0917
+    def __init__(
+        self,
+        model_type,
+        input_dim,
+        hidden_dim,
+        final_hidden_dim,
+        num_layers,
+        activation,
+        query_scale,
+        seed,
+        output_dim=None,
+        training=None,
+    ):
+        """
+        Creates a LEMUR feature model.
+
+        Args:
+            model_type: elm or mlp
+            input_dim: token-vector dimension
+            hidden_dim: MLP hidden dimension
+            final_hidden_dim: fixed output dimension
+            num_layers: number of MLP feature layers
+            activation: feature activation
+            query_scale: query feature sum scale
+            seed: artifact seed
+            output_dim: optional number of training target documents
+            training: optional fit-selection metadata
+        """
+
+        # Unused by model construction but retained in the serialized configuration
+        del query_scale, seed, training
+        super().__init__()
+
+        if model_type == "elm":
+            features = [
+                RandomFeatures(input_dim, final_hidden_dim, activation),
+                torch.nn.LayerNorm(final_hidden_dim, elementwise_affine=False),
+            ]
+        elif model_type == "mlp":
+            features = []
+            dimensions = [input_dim] + [hidden_dim] * (num_layers - 1)
+            for index, dimension in enumerate(dimensions):
+                output = final_hidden_dim if index == len(dimensions) - 1 else hidden_dim
+                features.extend([torch.nn.Linear(dimension, output), torch.nn.LayerNorm(output), Activation.module(activation)])
+        else:
+            raise ValueError("model_type must be elm or mlp")
+
+        self.feature_extractor = torch.nn.Sequential(*features)
+        self.output_layer = torch.nn.Linear(final_hidden_dim, output_dim, bias=False) if output_dim is not None else None
+
+    def forward(self, data):
+        """
+        Runs feature extraction and the training readout.
+
+        Args:
+            data: input token vectors
+
+        Returns:
+            predicted standardized maxsim targets
+        """
+
+        if self.output_layer is None:
+            raise ValueError("LEMUR training readout is not available in a loaded inference artifact")
+
+        return self.output_layer(self.features(data))
+
+    def features(self, data):
+        """
+        Extracts fixed dimensional token features.
+
+        Args:
+            data: input token vectors
+
+        Returns:
+            token features
+        """
+
+        return self.feature_extractor(data)
+
+
+class RandomFeatures(Module):
+    """
+    Seeded random activation features used by the ELM model.
+    """
+
+    def __init__(self, input_dim, output_dim, activation):
+        """
+        Creates random activation features.
+
+        Args:
+            input_dim: input token-vector dimension
+            output_dim: fixed feature dimension
+            activation: feature activation
+        """
+
+        super().__init__()
+        self.register_buffer("weight", torch.randn(input_dim, output_dim))
+        self.activation = activation
+        self.scale = math.sqrt(2.0 / output_dim)
+
+    def forward(self, data):
+        """
+        Projects and activates input vectors.
+
+        Args:
+            data: input token vectors
+
+        Returns:
+            random activation features
+        """
+
+        return self.scale * Activation.function(self.activation)(data @ self.weight)
+
+
+class Activation:
+    """
+    Activation helpers.
+    """
+
+    # Activation name to torch.nn module name. Modules and functions are resolved on demand to keep
+    # this module importable when Torch isn't installed.
+    MODULES = {"relu": "ReLU", "gelu": "GELU", "silu": "SiLU", "mish": "Mish"}
+
+    @staticmethod
+    def module(name):
+        """
+        Creates an activation module.
+
+        Args:
+            name: activation name
+
+        Returns:
+            activation module
+        """
+
+        Activation.validate(name)
+        return getattr(torch.nn, Activation.MODULES[name])()
+
+    @staticmethod
+    def function(name):
+        """
+        Gets an activation function.
+
+        Args:
+            name: activation name
+
+        Returns:
+            activation function
+        """
+
+        Activation.validate(name)
+        return getattr(torch.nn.functional, name)
+
+    @staticmethod
+    def validate(name):
+        """
+        Validates an activation name.
+
+        Args:
+            name: activation name
+        """
+
+        if name not in Activation.MODULES:
+            raise ValueError(f"activation must be one of: {', '.join(Activation.MODULES)}")

--- a/src/python/txtai/pipeline/text/lateencoder.py
+++ b/src/python/txtai/pipeline/text/lateencoder.py
@@ -22,6 +22,9 @@ class LateEncoder(Pipeline):
         # Get device
         self.device = Models.device(Models.deviceid(kwargs.get("gpu", True)))
 
+        # Disable fixed dimensional encoders to preserve raw multi-vectors
+        encoders = {"muvera": None, "lemur": None}
+
         # Load model
         self.model = PoolingFactory.create(
             {
@@ -30,7 +33,7 @@ class LateEncoder(Pipeline):
                 "device": self.device,
                 "tokenizer": kwargs.get("tokenizer"),
                 "maxlength": kwargs.get("maxlength"),
-                "modelargs": {**kwargs.get("vectors", {}), **{"muvera": None}},
+                "modelargs": {**kwargs.get("vectors", {}), **encoders},
             }
         )
 

--- a/src/python/txtai/pipeline/train/__init__.py
+++ b/src/python/txtai/pipeline/train/__init__.py
@@ -4,4 +4,5 @@ Train imports
 
 from .hfonnx import HFOnnx
 from .hftrainer import HFTrainer
+from .lemur import LemurTrainer
 from .mlonnx import MLOnnx

--- a/src/python/txtai/pipeline/train/lemur.py
+++ b/src/python/txtai/pipeline/train/lemur.py
@@ -1,0 +1,95 @@
+"""
+LEMUR trainer module
+"""
+
+import random
+
+from ...models import Lemur, Models, PoolingFactory
+from ..base import Pipeline
+
+
+class LemurTrainer(Pipeline):
+    """
+    Trains LEMUR artifacts for a late interaction model and corpus.
+    """
+
+    # pylint: disable=R0913,R0917
+    def __call__(
+        self,
+        path,
+        data,
+        output,
+        gpu=True,
+        method=None,
+        tokenizer=None,
+        maxlength=None,
+        vectors=None,
+        learn=None,
+        learn_category="query",
+        corpus_subset_size=None,
+        validation_split=0.0,
+        **kwargs,
+    ):
+        """
+        Trains a LEMUR feature encoder.
+
+        Args:
+            path: late interaction model path
+            data: iterable of corpus texts
+            output: artifact output directory
+            gpu: tensor accelerator setting
+            method: optional pooling method
+            tokenizer: optional tokenizer path
+            maxlength: maximum token length
+            vectors: additional model arguments
+            learn: optional iterable of texts used to learn features, defaults to data
+            learn_category: encoder category for learn texts (data or query)
+            corpus_subset_size: optional maximum number of corpus texts selected before encoding
+            validation_split: fraction of sampled learn tokens held out for validation
+            kwargs: LEMUR fit arguments
+
+        Returns:
+            fitted LEMUR encoder
+        """
+
+        data = list(data)
+        if not data:
+            raise ValueError("data must contain at least one corpus text")
+        if learn_category not in ("data", "query"):
+            raise ValueError("learn_category must be data or query")
+        if kwargs.get("epochs") is None:
+            raise ValueError("epochs must be set explicitly: use epochs=100 for trained MLP quality or epochs=0 for deterministic ELM features")
+        if corpus_subset_size is not None:
+            if isinstance(corpus_subset_size, bool) or not isinstance(corpus_subset_size, int) or corpus_subset_size <= 0:
+                raise ValueError("corpus_subset_size must be a positive integer")
+            if corpus_subset_size < len(data):
+                indices = sorted(random.Random(kwargs.get("seed", 42)).sample(range(len(data)), corpus_subset_size))
+                data = [data[index] for index in indices]
+
+        learn = list(learn) if learn is not None else None
+        if learn is not None and not learn:
+            raise ValueError("learn must contain at least one text")
+
+        deviceid = Models.deviceid(gpu)
+        modelargs = {**(vectors if vectors else {}), **{"muvera": None, "lemur": None}}
+        pooling = PoolingFactory.create(
+            {
+                "method": method,
+                "path": path,
+                "device": deviceid,
+                "tokenizer": tokenizer,
+                "maxlength": maxlength,
+                "modelargs": modelargs,
+            }
+        )
+
+        # A batch size of one preserves each document's true token count. The late
+        # pooling path normalizes token rows before returning raw multi-vectors.
+        documents = [pooling.encode([text], batch=1, category="data")[0] for text in data]
+        learn_documents = None
+        if learn is not None or learn_category != "data":
+            learn = data if learn is None else learn
+            learn_documents = [pooling.encode([text], batch=1, category=learn_category)[0] for text in learn]
+
+        lemur = Lemur(device=Models.device(deviceid))
+        return lemur.fit(documents, output=output, validation_split=validation_split, learn=learn_documents, **kwargs)

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -2,6 +2,7 @@
 Pooling module tests
 """
 
+import json
 import os
 import tempfile
 import unittest
@@ -194,6 +195,47 @@ class TestPooling(unittest.TestCase):
             self.assertIsNone(loaded.selected_loss)
             self.assertIsNone(loaded.selection_metric)
 
+            with self.assertRaisesRegex(ValueError, "LEMUR training readout is not available in a loaded inference artifact"):
+                loaded.model(torch.ones((1, 6)))
+
+            config = dict(loaded.config)
+            config["model_type"] = "invalid"
+            with open(os.path.join(output, "config.json"), "w", encoding="utf-8") as target:
+                json.dump(config, target)
+
+            with self.assertRaisesRegex(ValueError, "model_type must be elm or mlp"):
+                Lemur(output)
+
+    def testLemurDocuments(self):
+        """
+        Test LEMUR document input conversions and validation
+        """
+
+        lemur = Lemur()
+        matrix = np.ones((2, 3), dtype=np.float32)
+        batches = np.ones((2, 2, 3), dtype=np.float32)
+
+        documents = lemur.documents(matrix)
+        self.assertEqual(len(documents), 1)
+        self.assertEqual(documents[0].shape, (2, 3))
+
+        documents = lemur.documents(batches)
+        self.assertEqual(len(documents), 2)
+        self.assertTrue(all(document.shape == (2, 3) for document in documents))
+
+        tensor = torch.ones((2, 3), dtype=torch.float64)
+        document = lemur.documents([tensor])[0]
+        self.assertEqual(document.dtype, torch.float32)
+        self.assertEqual(document.shape, (2, 3))
+
+        document = lemur.documents([[[1.0, 2.0], [3.0, 4.0]]])[0]
+        self.assertEqual(document.shape, (2, 2))
+
+        for invalid in ([np.ones(3, dtype=np.float32)], [np.empty((0, 3), dtype=np.float32)]):
+            with self.subTest(shape=invalid[0].shape):
+                with self.assertRaisesRegex(ValueError, "each document must be a non-empty 2D token-vector array"):
+                    lemur.documents(invalid)
+
     def testLemurEpochChoice(self):
         """
         Test LEMUR requires an explicit MLP or ELM epoch choice
@@ -326,6 +368,71 @@ class TestPooling(unittest.TestCase):
                 with self.subTest(setting=setting, value=value):
                     with self.assertRaisesRegex(ValueError, f"{setting} must be greater than 0"):
                         Lemur().fit(documents, epochs=0, **{setting: value})
+
+    def testLemurFitValidation(self):
+        """
+        Test LEMUR rejects invalid fit inputs
+        """
+
+        documents = [
+            np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32),
+            np.array([[0.5, 0.5]], dtype=np.float32),
+        ]
+        tests = [
+            ("epochs", documents, {"epochs": -1}, "epochs must be greater than or equal to 0"),
+            ("final hidden dimension", documents, {"epochs": 0, "final_hidden_dim": 0}, "final_hidden_dim must be greater than 0"),
+            (
+                "validation split",
+                documents,
+                {"epochs": 0, "validation_split": 1.0},
+                "validation_split must be greater than or equal to 0 and less than 1",
+            ),
+            ("empty data", [], {"epochs": 0}, "data must contain at least one document"),
+            (
+                "data dimension",
+                [np.ones((1, 2), dtype=np.float32), np.ones((1, 3), dtype=np.float32)],
+                {"epochs": 0},
+                "all token vectors must have the same dimension",
+            ),
+            ("empty learn", documents, {"epochs": 0, "learn": []}, "learn must contain at least one document"),
+            (
+                "learn dimension",
+                documents,
+                {"epochs": 0, "learn": [np.ones((1, 3), dtype=np.float32)]},
+                "all learn token vectors must match the data dimension",
+            ),
+            (
+                "validation training subset",
+                documents,
+                {"epochs": 0, "learn": [np.ones((1, 2), dtype=np.float32)], "validation_split": 0.5},
+                "validation_split must leave at least one learn token for training",
+            ),
+            (
+                "zero variance",
+                [np.ones((1, 2), dtype=np.float32), np.ones((1, 2), dtype=np.float32)],
+                {"epochs": 0},
+                "LEMUR targets have zero variance",
+            ),
+        ]
+
+        for name, data, settings, message in tests:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, message):
+                    Lemur().fit(data, **settings)
+
+    def testLemurStateValidation(self):
+        """
+        Test LEMUR rejects invalid categories and unfitted encoding
+        """
+
+        lemur = Lemur()
+        documents = [np.ones((1, 2), dtype=np.float32)]
+
+        with self.assertRaisesRegex(ValueError, "category must be query or data"):
+            lemur(documents, "invalid")
+
+        with self.assertRaisesRegex(ValueError, "LEMUR must be fitted or loaded before encoding"):
+            lemur(documents, "query")
 
     def testLemurActivations(self):
         """

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -2,9 +2,16 @@
 Pooling module tests
 """
 
+import os
+import tempfile
 import unittest
 
-from txtai.models import Models, ClsPooling, LastPooling, MeanPooling, PoolingFactory
+import numpy as np
+import torch
+
+from txtai.models import Models, ClsPooling, LastPooling, Lemur, MeanPooling, PoolingFactory
+from txtai.models.pooling.lemur import Activation
+from txtai.pipeline import LemurTrainer
 
 
 class TestPooling(unittest.TestCase):
@@ -102,6 +109,245 @@ class TestPooling(unittest.TestCase):
                 {"path": model, "device": self.device, "modelargs": {"muvera": {"repetitions": 5, "hashes": 2, "projection": 8}}}
             )
             self.assertEqual(pooling.encode(["test"], category="data").shape, (1, 160))
+
+    def testLemur(self):
+        """
+        Test late pooling with LEMUR fixed dimensional encoding
+        """
+
+        corpus = [
+            "Machine learning models retrieve relevant passages.",
+            "Late interaction compares token embeddings.",
+            "Dense indexes search fixed dimensional vectors.",
+            "A query encoder produces contextual token vectors.",
+            "Document encoders represent passages for retrieval.",
+            "Maximum similarity aggregates token matches.",
+            "LEMUR learns a corpus specific reduction.",
+            "MUVERA uses randomized fixed dimensional encodings.",
+            "The trainer stores reusable pooling artifacts.",
+            "New documents can be encoded after training.",
+            "Short text.",
+            "A considerably longer synthetic document exercises padding behavior.",
+        ] * 2
+
+        for model in ["neuml/colbert-bert-tiny", "neuml/pylate-bert-tiny"]:
+            with tempfile.TemporaryDirectory() as output:
+                LemurTrainer()(
+                    model,
+                    corpus,
+                    output,
+                    gpu=False,
+                    epochs=0,
+                    final_hidden_dim=128,
+                    train_subset_size=24,
+                    learn_subset_size=256,
+                    ols_sample_size=128,
+                    seed=42,
+                )
+
+                pooling = PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"lemur": {"path": output}}})
+                texts = ["Short text.", "A considerably longer synthetic document exercises padding behavior."]
+                queries = pooling.encode(texts, category="query")
+                documents = pooling.encode(texts, category="data")
+
+                self.assertEqual(queries.shape, (2, 128))
+                self.assertEqual(documents.shape, (2, 128))
+                self.assertTrue(np.isfinite(queries).all())
+                self.assertTrue(np.isfinite(documents).all())
+
+                # LEMUR must use true token counts, independent of batch padding
+                singles = np.vstack([pooling.encode([text], category="data") for text in texts])
+                np.testing.assert_allclose(documents, singles, rtol=1e-5, atol=1e-6)
+
+            # MUVERA remains the default when LEMUR is absent
+            pooling = PoolingFactory.create({"path": model, "device": self.device})
+            self.assertEqual(pooling.encode(["test"], category="query").shape, (1, 10240))
+
+    def testLemurRoundTrip(self):
+        """
+        Test an ordinary LEMUR artifact save/load round-trip
+        """
+
+        random = np.random.default_rng(42)
+        documents = [random.normal(size=(5, 6)).astype(np.float32) for _ in range(8)]
+        queries = [random.normal(size=(3, 6)).astype(np.float32) for _ in range(2)]
+
+        with tempfile.TemporaryDirectory() as output:
+            fitted = Lemur().fit(
+                documents,
+                output=output,
+                epochs=0,
+                final_hidden_dim=10,
+                train_subset_size=8,
+                learn_subset_size=40,
+                ols_sample_size=24,
+                seed=42,
+            )
+            self.assertEqual(set(os.listdir(output)), {"config.json", "model.safetensors"})
+            loaded = Lemur(output)
+
+            # Float32 feature and SVD kernels can vary across Torch/BLAS builds.
+            np.testing.assert_allclose(loaded(queries, "query"), fitted(queries, "query"), rtol=1e-5, atol=1e-6)
+            np.testing.assert_allclose(loaded(documents, "data"), fitted(documents, "data"), rtol=1e-5, atol=1e-6)
+            self.assertIsNone(loaded.model.output_layer)
+            self.assertIsNone(loaded.selected_epoch)
+            self.assertIsNone(loaded.selected_loss)
+            self.assertIsNone(loaded.selection_metric)
+
+    def testLemurEpochChoice(self):
+        """
+        Test LEMUR requires an explicit MLP or ELM epoch choice
+        """
+
+        random = np.random.default_rng(42)
+        documents = [random.normal(size=(5, 6)).astype(np.float32) for _ in range(8)]
+
+        with self.assertRaisesRegex(ValueError, r"epochs must be set explicitly.*epochs=100.*epochs=0"):
+            Lemur().fit(documents)
+
+    def testLemurDefaultEquivalence(self):
+        """
+        Test implicit and explicit fit defaults are numerically equivalent
+        """
+
+        random = np.random.default_rng(42)
+        documents = [random.normal(size=(5, 6)).astype(np.float32) for _ in range(8)]
+        queries = [random.normal(size=(3, 6)).astype(np.float32) for _ in range(2)]
+        settings = {
+            "epochs": 4,
+            "lr": 0.01,
+            "batch_size": 8,
+            "hidden_dim": 12,
+            "final_hidden_dim": 10,
+            "train_subset_size": 8,
+            "learn_subset_size": 40,
+            "ols_sample_size": 24,
+            "seed": 42,
+        }
+        implicit = Lemur().fit(documents, **settings)
+        explicit = Lemur().fit(documents, validation_split=0.0, **settings)
+
+        # Verify portable numerical equivalence instead of cross-platform bit identity.
+        np.testing.assert_allclose(implicit(queries, "query"), explicit(queries, "query"), rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(implicit(documents, "data"), explicit(documents, "data"), rtol=1e-5, atol=1e-6)
+
+    def testLemurValidationSelection(self):
+        """
+        Test validation loss selects and records the retained MLP epoch
+        """
+
+        random = np.random.default_rng(1)
+        documents = [random.normal(size=(5, 6)).astype(np.float32) for _ in range(8)]
+
+        with tempfile.TemporaryDirectory() as output:
+            lemur = Lemur().fit(
+                documents,
+                output=output,
+                epochs=20,
+                lr=0.03,
+                batch_size=8,
+                hidden_dim=12,
+                final_hidden_dim=10,
+                train_subset_size=8,
+                learn_subset_size=40,
+                ols_sample_size=24,
+                validation_split=0.25,
+                seed=7,
+            )
+            reloaded = Lemur(output)
+
+            self.assertEqual(lemur.selection_metric, "validation_loss")
+            self.assertGreaterEqual(lemur.selected_epoch, 1)
+            self.assertLess(lemur.selected_epoch, 20)
+            self.assertTrue(np.isfinite(lemur.selected_loss))
+            self.assertEqual(reloaded.selected_epoch, lemur.selected_epoch)
+            self.assertEqual(reloaded.selected_loss, lemur.selected_loss)
+            self.assertEqual(reloaded.selection_metric, lemur.selection_metric)
+
+    def testLemurRanking(self):
+        """
+        Test LEMUR ranking quality on pinned synthetic data
+        """
+
+        np.random.seed(42)
+        torch.manual_seed(42)
+
+        documents = []
+        for _ in range(64):
+            vectors = np.random.normal(size=(np.random.randint(4, 13), 32)).astype(np.float32)
+            documents.append(vectors / np.linalg.norm(vectors, axis=1, keepdims=True))
+
+        targets = np.random.choice(64, size=8, replace=False)
+        queries = []
+        for target in targets:
+            vectors = documents[target] + np.random.normal(0.0, 0.1, size=documents[target].shape).astype(np.float32)
+            queries.append(vectors / np.linalg.norm(vectors, axis=1, keepdims=True))
+
+        exact = np.asarray([[np.einsum("qd,nd->qn", query, document).max(axis=1).sum() for document in documents] for query in queries])
+        exact = np.argsort(-exact, axis=1)
+
+        lemur = Lemur()
+        lemur.fit(
+            documents,
+            epochs=0,
+            final_hidden_dim=256,
+            train_subset_size=64,
+            learn_subset_size=sum(len(document) for document in documents),
+            ols_sample_size=sum(len(document) for document in documents),
+            seed=42,
+        )
+        approximate = lemur(queries, "query") @ lemur(documents, "data").T
+        approximate = np.argsort(-approximate, axis=1)
+
+        overlap = np.mean([len(set(exact[x, :10]) & set(approximate[x, :10])) / 10 for x in range(8)])
+        top1 = np.sum(exact[:, 0] == approximate[:, 0])
+
+        self.assertGreaterEqual(overlap, 0.6)
+        self.assertGreaterEqual(top1, 6)
+
+    def testLemurSettingsValidation(self):
+        """
+        Test LEMUR rejects non-positive settings
+        """
+
+        random = np.random.default_rng(42)
+        documents = [random.normal(size=(5, 6)).astype(np.float32) for _ in range(8)]
+        settings = [
+            "ols_sample_size",
+            "query_scale",
+            "num_layers",
+            "batch_size",
+            "train_subset_size",
+            "learn_subset_size",
+        ]
+
+        for setting in settings:
+            for value in (0, -1):
+                with self.subTest(setting=setting, value=value):
+                    with self.assertRaisesRegex(ValueError, f"{setting} must be greater than 0"):
+                        Lemur().fit(documents, epochs=0, **{setting: value})
+
+    def testLemurActivations(self):
+        """
+        Test LEMUR activations resolve to Torch modules and functions
+        """
+
+        data = torch.tensor([-1.0, 0.0, 0.5, 2.0])
+        expected = {
+            "relu": (torch.nn.ReLU, torch.relu),
+            "gelu": (torch.nn.GELU, torch.nn.functional.gelu),
+            "silu": (torch.nn.SiLU, torch.nn.functional.silu),
+            "mish": (torch.nn.Mish, torch.nn.functional.mish),
+        }
+
+        for name, (module, function) in expected.items():
+            with self.subTest(activation=name):
+                self.assertIsInstance(Activation.module(name), module)
+                self.assertTrue(torch.equal(Activation.function(name)(data), function(data)))
+
+        for method in (Activation.module, Activation.function):
+            with self.assertRaisesRegex(ValueError, "activation must be one of: relu, gelu, silu, mish"):
+                method("invalid")
 
     def testPrompts(self):
         """

--- a/test/python/testpipeline/testtrain/testtrainer.py
+++ b/test/python/testpipeline/testtrain/testtrainer.py
@@ -318,6 +318,26 @@ class TestTrainer(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "corpus_subset_size must be a positive integer"):
             LemurTrainer()("model", corpus, "output", gpu=False, epochs=0, corpus_subset_size=0)
 
+    def testLemurTrainerValidation(self):
+        """
+        Test LEMUR trainer validates inputs before loading a model
+        """
+
+        tests = [
+            ([], {"epochs": 0}, "data must contain at least one corpus text"),
+            (["text"], {"epochs": 0, "learn_category": "invalid"}, "learn_category must be data or query"),
+            (["text"], {}, "epochs must be set explicitly"),
+            (["text"], {"epochs": 0, "learn": []}, "learn must contain at least one text"),
+        ]
+
+        with patch("txtai.pipeline.train.lemur.PoolingFactory.create") as create:
+            for data, settings, message in tests:
+                with self.subTest(message=message):
+                    with self.assertRaisesRegex(ValueError, message):
+                        LemurTrainer()("model", data, "output", gpu=False, **settings)
+
+            create.assert_not_called()
+
     def testMLM(self):
         """
         Test training a model with masked language modeling.

--- a/test/python/testpipeline/testtrain/testtrainer.py
+++ b/test/python/testpipeline/testtrain/testtrainer.py
@@ -5,13 +5,16 @@ Trainer module tests
 import os
 import unittest
 import tempfile
+from unittest.mock import patch
 
+import numpy as np
 import torch
 
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 from txtai.data import Data
-from txtai.pipeline import HFTrainer, Labels, Questions, Sequences
+from txtai.models import Lemur, Models, PoolingFactory
+from txtai.pipeline import HFTrainer, Labels, LemurTrainer, Questions, Sequences
 
 
 class TestTrainer(unittest.TestCase):
@@ -206,6 +209,114 @@ class TestTrainer(unittest.TestCase):
 
         labels = Labels((model, tokenizer), dynamic=False)
         self.assertEqual(labels("cat")[0][0], 1)
+
+    def testLemurTrainer(self):
+        """
+        Test LEMUR trainer artifact round-trip and seeded determinism
+        """
+
+        model = "neuml/colbert-bert-tiny"
+        corpus = [
+            "alpha beta gamma",
+            "beta gamma delta",
+            "retrieval with token vectors",
+            "fixed dimensional document weights",
+            "learned maximum similarity",
+            "deterministic trainer artifacts",
+        ] * 2
+        settings = {
+            "gpu": False,
+            "epochs": 0,
+            "final_hidden_dim": 128,
+            "train_subset_size": 12,
+            "learn_subset_size": 128,
+            "ols_sample_size": 64,
+            "seed": 42,
+        }
+
+        raw = PoolingFactory.create(
+            {
+                "path": model,
+                "device": Models.deviceid(False),
+                "modelargs": {"muvera": None, "lemur": None},
+            }
+        )
+        documents = [raw.encode([text], batch=1, category="data")[0] for text in corpus[:3]]
+        queries = [raw.encode([text], batch=1, category="query")[0] for text in corpus[:2]]
+
+        with (
+            tempfile.TemporaryDirectory() as first,
+            tempfile.TemporaryDirectory() as second,
+            tempfile.TemporaryDirectory() as third,
+        ):
+            trained = LemurTrainer()(model, corpus, first, **settings)
+            reloaded = Lemur(first)
+            explicit_query = LemurTrainer()(model, corpus, second, learn=corpus, learn_category="query", **settings)
+            data_learn = LemurTrainer()(model, corpus, third, learn=corpus, learn_category="data", **settings)
+            query_reloaded = Lemur(second)
+
+            trained_queries = torch.from_numpy(trained(queries, "query"))
+            trained_documents = torch.from_numpy(trained(documents, "data"))
+            data_documents = torch.from_numpy(data_learn(documents, "data"))
+
+            # Float32 encoder and SVD kernels can vary across Torch/BLAS builds.
+            self.assertTrue(torch.allclose(trained_queries, torch.from_numpy(reloaded(queries, "query")), rtol=1e-5, atol=1e-6))
+            self.assertTrue(torch.allclose(trained_documents, torch.from_numpy(reloaded(documents, "data")), rtol=1e-5, atol=1e-6))
+            np.testing.assert_allclose(trained_queries.numpy(), explicit_query(queries, "query"), rtol=1e-5, atol=1e-6)
+            np.testing.assert_allclose(trained_documents.numpy(), explicit_query(documents, "data"), rtol=1e-5, atol=1e-6)
+            self.assertFalse(torch.allclose(trained.sample, data_learn.sample, rtol=1e-5, atol=1e-6))
+            self.assertFalse(torch.allclose(trained_documents, data_documents, rtol=1e-5, atol=1e-6))
+            self.assertTrue(torch.allclose(trained_documents, torch.from_numpy(query_reloaded(documents, "data")), rtol=1e-5, atol=1e-6))
+
+    def testLemurTrainerCorpusSubset(self):
+        """
+        Test LEMUR samples corpus texts before deterministic encoding
+        """
+
+        class Pooling:
+            """
+            Records raw text encoding calls.
+            """
+
+            def __init__(self):
+                self.calls = []
+
+            def encode(self, texts, batch, category):
+                """
+                Records and returns a synthetic token vector.
+                """
+
+                self.calls.append((texts[0], category, batch))
+                return [torch.ones((1, 2))]
+
+        corpus = [f"document {index}" for index in range(12)]
+        runs = []
+        for _ in range(2):
+            pooling = Pooling()
+            with (
+                patch("txtai.pipeline.train.lemur.PoolingFactory.create", return_value=pooling),
+                patch.object(Lemur, "fit", autospec=True, return_value=None),
+            ):
+                LemurTrainer()("model", corpus, "output", gpu=False, epochs=0, corpus_subset_size=4, seed=7)
+            runs.append(pooling.calls)
+
+        self.assertEqual(runs[0], runs[1])
+        data = [text for text, category, _ in runs[0] if category == "data"]
+        learn = [text for text, category, _ in runs[0] if category == "query"]
+        self.assertEqual(len(data), 4)
+        self.assertEqual(data, learn)
+
+        pooling = Pooling()
+        with (
+            patch("txtai.pipeline.train.lemur.PoolingFactory.create", return_value=pooling),
+            patch.object(Lemur, "fit", autospec=True, return_value=None),
+        ):
+            LemurTrainer()("model", corpus, "output", gpu=False, epochs=0)
+        self.assertEqual(len([call for call in pooling.calls if call[1] == "data"]), len(corpus))
+        self.assertEqual(len([call for call in pooling.calls if call[1] == "query"]), len(corpus))
+
+        with self.assertRaisesRegex(ValueError, "corpus_subset_size must be a positive integer"):
+            LemurTrainer()("model", corpus, "output", gpu=False, epochs=0, corpus_subset_size=0)
 
     def testMLM(self):
         """


### PR DESCRIPTION
Adds a LEMUR fixed dimensional encoder for late-interaction models and a separate `LemurTrainer` pipeline. It uses the requested trainer, artifact, and pooling structure: training writes `config.json` and `model.safetensors`, and the pooling module loads either a local directory or Hugging Face Hub repository through the standard loader. The existing late-pooling scaffolding handles LEMUR alongside MUVERA, and `lateencoder.py` disables `muvera` and `lemur` through one encoder dictionary while producing raw multi-vectors.

## Benchmark

Measured on one machine with one GPU using `colbert-ir/colbertv2.0`, torch 2.13.0+cu130, and exact `IDMap,Flat`. Each cell is NDCG@10 / fixed-vector index KB.

| Dataset | MUVERA 10,240 | MUVERA 2,048 | LEMUR ELM 2,048 | LEMUR MLP 2,048 |
|---|---:|---:|---:|---:|
| nfcorpus | 0.23544 / 145,380 | 0.16299 / 29,124 | 0.21591 / 29,124 | **0.25524 / 29,124** |
| scifact | 0.50021 / 207,404 | 0.36757 / 41,548 | 0.50251 / 41,548 | **0.54910 / 41,548** |
| arguana | 0.34614 / 347,337 | 0.26280 / 69,769 | 0.34207 / 69,769 | **0.42556 / 69,769** |

At the equal 2,048-dimensional vector budget, LEMUR-MLP improves NDCG@10 over matched-size MUVERA by +56.6% on nfcorpus, +49.4% on scifact, and +61.9% on arguana. Against default 10,240-dimensional MUVERA, the gains are +8.4%, +9.8%, and +22.9% with one-fifth the fixed-vector index size. The same ordering holds on MAP@10, Recall@10, and P@10 for both comparisons on all three datasets. The untrained ELM path needs no training and beats matched-size MUVERA on all three; on scifact and arguana it lands within noise of full-size MUVERA at one-fifth the index size.

This covers three of the five datasets in the benchmark set: arguana, nfcorpus, and scifact. Scidocs and fiqa remain to be run because of a benchmark-machine hardware fault.

## Limitation: default IVF above 5,000 rows

These measurements use txtai's normalized single-stage path; fixed vectors are L2-normalized and dense results with non-positive scores are filtered. All values above pin exact search. txtai selects exact `IDMap,Flat` through 5,000 rows and IVF above that threshold. On scifact, the measured change under default IVF is roughly -43% NDCG@10 for LEMUR versus -25% for MUVERA. LEMUR is materially more sensitive to coarse quantization, so a corpus above 5,000 rows should pin an exact index or tune IVF.

## Training and API

The learn distribution was the main training result. In the nfcorpus CPU ablation, encoding learn tokens with the document encoder produced a trained MLP at 0.15870 NDCG@10, below the untrained ELM at 0.19187. The query-encoded path is the one used in the table above, where trained LEMUR is +49.4% to +61.9% over matched-size MUVERA, so `learn_category` defaults to `"query"`.

`epochs` has no silent default: callers pass `100` for trained MLP quality or `0` for deterministic ELM features. `corpus_subset_size` bounds encoding for large corpora by sampling raw corpus texts before either encoding pass, and `validation_split` enables validation-based epoch selection. Artifacts use `config.json` and `model.safetensors` through the standard Hub/local loader.

## Compatibility and scope

MUVERA is unchanged. The `muvera.py` checksum matches the released source, LEMUR-only handling is gated off its path, and saved MUVERA reference encodings remain bit-identical.

A corpus-independent LEMUR model is not addressed here. The paper treats the reduction as corpus-specific, and I have not tested cross-corpus generalization; a general-model experiment is a natural follow-up.

Based on the [LEMUR paper](https://arxiv.org/abs/2601.21853) and its [MIT reference implementation](https://github.com/ejaasaari/lemur).

Closes #1024
