### PR TITLE
Add configurable mean centering to late pooling

### DIFF
--- a/docs/embeddings/configuration/vectors.md
+++ b/docs/embeddings/configuration/vectors.md
@@ -151,7 +151,7 @@ center: boolean | dict
 ```
 
 Centers normalized late-interaction token vectors and normalizes them again before MUVERA or LEMUR encoding. Centering is applied to
-both query and document vectors. `true` uses document scope and `false` disables centering. When omitted, centering defaults to document
+both query and document vectors. `true` uses batch scope and `false` disables centering. When omitted, centering defaults to batch
 scope only for late-interaction models that load more than one `torch.nn.Linear` layer; models with zero or one loaded linear layer keep
 their previous output.
 
@@ -164,7 +164,7 @@ center:
 
 `document` subtracts the mean of each document or query independently. `batch` subtracts the mean of all real token rows in the current
 model batch. `collection` requires a caller-provided, one-dimensional mean vector through either `mean` (an array-like value) or `path`
-(a NumPy `.npy` file), but not both. Zero-padding rows are never centered and remain zero.
+(a safetensors file containing a `center.mean` tensor), but not both. Zero-padding rows are never centered and remain zero.
 
 ### muvera
 ```yaml

--- a/docs/embeddings/configuration/vectors.md
+++ b/docs/embeddings/configuration/vectors.md
@@ -145,6 +145,27 @@ vectors: dict
 
 Passes these additional parameters to the underlying vector model.
 
+### center
+```yaml
+center: boolean | dict
+```
+
+Centers normalized late-interaction token vectors and normalizes them again before MUVERA or LEMUR encoding. Centering is applied to
+both query and document vectors. `true` uses document scope and `false` disables centering. When omitted, centering defaults to document
+scope only for late-interaction models that load more than one `torch.nn.Linear` layer; models with zero or one loaded linear layer keep
+their previous output.
+
+Dictionary configuration supports the following scopes:
+
+```yaml
+center:
+    scope: document | batch | collection
+```
+
+`document` subtracts the mean of each document or query independently. `batch` subtracts the mean of all real token rows in the current
+model batch. `collection` requires a caller-provided, one-dimensional mean vector through either `mean` (an array-like value) or `path`
+(a NumPy `.npy` file), but not both. Zero-padding rows are never centered and remain zero.
+
 ### muvera
 ```yaml
 muvera:

--- a/src/python/txtai/models/pooling/late.py
+++ b/src/python/txtai/models/pooling/late.py
@@ -179,12 +179,12 @@ class LatePooling(Pooling):
             resolved token centering configuration
         """
 
-        # Enable document centering by default for multi-linear models
+        # Enable batch centering by default for multi-linear models
         if not configured:
             center = sum(isinstance(module, torch.nn.Linear) for module in linear.modules()) > 1
 
         if isinstance(center, bool):
-            return {"scope": "document"} if center else None
+            return {"scope": "batch"} if center else None
 
         if not isinstance(center, dict):
             raise ValueError("center must be a boolean or dictionary")
@@ -206,7 +206,12 @@ class LatePooling(Pooling):
             if (mean is None) == (path is None):
                 raise ValueError("collection center scope requires exactly one of mean or path")
 
-            mean = np.load(path, allow_pickle=False) if path is not None else np.asarray(mean)
+            if path is not None:
+                with safetensors.safe_open(path, framework="np") as source:
+                    mean = source.get_tensor("center.mean")
+            else:
+                mean = np.asarray(mean)
+
             if mean.ndim != 1 or not np.isfinite(mean).all():
                 raise ValueError("collection center mean must be a finite one-dimensional array")
 
@@ -242,18 +247,16 @@ class LatePooling(Pooling):
             means = [self.center["mean"]] * len(vectors)
 
         for x, (value, mask) in enumerate(zip(vectors, masks)):
-            if not mask.any():
-                continue
+            if mask.any():
+                current = value[mask]
+                average = current.mean(axis=0) if scope == "document" else means[x]
+                if average is not None and average.shape != (current.shape[1],):
+                    raise ValueError("center mean dimension must match token vector dimension")
 
-            current = value[mask]
-            average = current.mean(axis=0) if scope == "document" else means[x]
-            if average is not None and average.shape != (current.shape[1],):
-                raise ValueError("center mean dimension must match token vector dimension")
-
-            current = current - average
-            norms = np.linalg.norm(current, axis=1, keepdims=True)
-            current = np.divide(current, norms, out=np.zeros_like(current), where=norms != 0)
-            vectors[x][mask] = current
+                current = current - average
+                norms = np.linalg.norm(current, axis=1, keepdims=True)
+                current = np.divide(current, norms, out=np.zeros_like(current), where=norms != 0)
+                vectors[x][mask] = current
 
         return np.asarray(vectors) if array else vectors
 

--- a/src/python/txtai/models/pooling/late.py
+++ b/src/python/txtai/models/pooling/late.py
@@ -26,6 +26,8 @@ class LatePooling(Pooling):
         modelargs = modelargs.copy() if modelargs else {}
         muvera = modelargs.pop("muvera", {})
         lemur = modelargs.pop("lemur", None)
+        centerconfigured = "center" in modelargs
+        center = modelargs.pop("center", None)
 
         # Call parent initialization
         super().__init__(path, device, tokenizer, maxlength, loadprompts, modelargs)
@@ -49,6 +51,10 @@ class LatePooling(Pooling):
         # Load linear model
         self.linear = self.loadlinear(path, models)
 
+        # Configure token centering
+        self.center = self.centersettings(center, self.linear, centerconfigured)
+        self.batches = None
+
     def forward(self, **inputs):
         """
         Runs late pooling on token embeddings.
@@ -60,9 +66,13 @@ class LatePooling(Pooling):
             Late pooled embeddings using output token embeddings (i.e. last hidden state)
         """
 
-        # Track true token counts for encoders that can't consume padding
-        if getattr(self.encoder, "unpadded", False):
+        # Track true token counts for centering and encoders that can't consume padding
+        if self.center or getattr(self.encoder, "unpadded", False):
             self.lengths.extend(inputs["attention_mask"].sum(dim=1).cpu().tolist())
+
+        # Track model batch boundaries for batch-scoped centering
+        if self.center and self.center["scope"] == "batch":
+            self.batches.append(inputs["attention_mask"].shape[0])
 
         # Run through transformers model
         tokens = super().forward(**inputs)
@@ -80,8 +90,11 @@ class LatePooling(Pooling):
         """
 
         # Reset true token counts for this encoding pass
-        if getattr(self.encoder, "unpadded", False):
+        if self.center or getattr(self.encoder, "unpadded", False):
             self.lengths = []
+
+        if self.center and self.center["scope"] == "batch":
+            self.batches = []
 
         results = []
 
@@ -119,7 +132,14 @@ class LatePooling(Pooling):
                 vectors /= np.linalg.norm(vectors, axis=1)[:, np.newaxis]
                 data.append(vectors)
 
+            if self.center:
+                data = self.centerdata(data)
+
             return self.encoder(data, category)
+
+        # Remove model padding before normalization. Padding is restored as exact zeros below.
+        if self.center:
+            results = [vectors[:length] for vectors, length in zip(results, self.lengths)]
 
         length = 0
         for vectors in results:
@@ -138,8 +158,104 @@ class LatePooling(Pooling):
         # Build NumPy array
         data = np.asarray(data)
 
+        # Center true token rows before fixed dimensional encoding
+        if self.center:
+            data = self.centerdata(data)
+
         # Apply fixed dimesional encoder, if necessary
         return self.encoder(data, category) if self.encoder else data
+
+    @staticmethod
+    def centersettings(center, linear, configured):
+        """
+        Validates and resolves token centering settings.
+
+        Args:
+            center: token centering configuration
+            linear: loaded linear model
+            configured: whether center was explicitly configured
+
+        Returns:
+            resolved token centering configuration
+        """
+
+        # Enable document centering by default for multi-linear models
+        if not configured:
+            center = sum(isinstance(module, torch.nn.Linear) for module in linear.modules()) > 1
+
+        if isinstance(center, bool):
+            return {"scope": "document"} if center else None
+
+        if not isinstance(center, dict):
+            raise ValueError("center must be a boolean or dictionary")
+
+        center = center.copy()
+        scope = center.pop("scope", "document")
+        if scope not in ("document", "batch", "collection"):
+            raise ValueError("center scope must be one of: document, batch, collection")
+
+        mean = center.pop("mean", None)
+        path = center.pop("path", None)
+        if center:
+            raise ValueError(f"unknown center setting: {next(iter(center))}")
+
+        if scope != "collection" and (mean is not None or path is not None):
+            raise ValueError("center mean and path are only valid with collection scope")
+
+        if scope == "collection":
+            if (mean is None) == (path is None):
+                raise ValueError("collection center scope requires exactly one of mean or path")
+
+            mean = np.load(path, allow_pickle=False) if path is not None else np.asarray(mean)
+            if mean.ndim != 1 or not np.isfinite(mean).all():
+                raise ValueError("collection center mean must be a finite one-dimensional array")
+
+        return {"scope": scope, "mean": mean} if scope == "collection" else {"scope": scope}
+
+    def centerdata(self, data):
+        """
+        Centers and re-normalizes true token rows.
+
+        Args:
+            data: normalized token vectors, with optional zero padding
+
+        Returns:
+            centered token vectors with zero padding preserved
+        """
+
+        array = isinstance(data, np.ndarray)
+        vectors = [np.array(value, copy=True) for value in data]
+        masks = [np.any(value != 0, axis=1) for value in vectors]
+        scope = self.center["scope"]
+
+        means = [None] * len(vectors)
+        if scope == "batch":
+            batches = getattr(self, "batches", None)
+            sizes = batches if batches and sum(batches) == len(vectors) else [len(vectors)]
+            offset = 0
+            for size in sizes:
+                rows = [vectors[x][masks[x]] for x in range(offset, offset + size) if masks[x].any()]
+                mean = np.concatenate(rows).mean(axis=0) if rows else None
+                means[offset : offset + size] = [mean] * size
+                offset += size
+        elif scope == "collection":
+            means = [self.center["mean"]] * len(vectors)
+
+        for x, (value, mask) in enumerate(zip(vectors, masks)):
+            if not mask.any():
+                continue
+
+            current = value[mask]
+            average = current.mean(axis=0) if scope == "document" else means[x]
+            if average is not None and average.shape != (current.shape[1],):
+                raise ValueError("center mean dimension must match token vector dimension")
+
+            current = current - average
+            norms = np.linalg.norm(current, axis=1, keepdims=True)
+            current = np.divide(current, norms, out=np.zeros_like(current), where=norms != 0)
+            vectors[x][mask] = current
+
+        return np.asarray(vectors) if array else vectors
 
     def settings(self, path, config):
         """

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from safetensors.numpy import save_file
 import torch
 
 from txtai.models import Models, ClsPooling, LastPooling, LatePooling, Lemur, MeanPooling, PoolingFactory
@@ -124,10 +125,11 @@ class TestPooling(unittest.TestCase):
 
         self.assertIsNone(LatePooling.centersettings(None, empty, False))
         self.assertIsNone(LatePooling.centersettings(None, single, False))
-        self.assertEqual(LatePooling.centersettings(None, multiple, False), {"scope": "document"})
+        self.assertEqual(LatePooling.centersettings(None, multiple, False), {"scope": "batch"})
         self.assertIsNone(LatePooling.centersettings(False, multiple, True))
-        self.assertEqual(LatePooling.centersettings(True, empty, True), {"scope": "document"})
+        self.assertEqual(LatePooling.centersettings(True, empty, True), {"scope": "batch"})
         self.assertEqual(LatePooling.centersettings({"scope": "batch"}, empty, True), {"scope": "batch"})
+        self.assertEqual(LatePooling.centersettings({"scope": "document"}, empty, True), {"scope": "document"})
 
     def testLateCenterSettings(self):
         """
@@ -140,8 +142,8 @@ class TestPooling(unittest.TestCase):
         np.testing.assert_array_equal(settings["mean"], mean)
 
         with tempfile.TemporaryDirectory() as output:
-            path = os.path.join(output, "mean.npy")
-            np.save(path, mean)
+            path = os.path.join(output, "mean.safetensors")
+            save_file({"center.mean": mean}, path)
             settings = LatePooling.centersettings({"scope": "collection", "path": path}, linear, True)
             np.testing.assert_array_equal(settings["mean"], mean)
 
@@ -149,7 +151,7 @@ class TestPooling(unittest.TestCase):
             (None, "center must be a boolean or dictionary"),
             ({"scope": "invalid"}, "center scope must be one of"),
             ({"scope": "collection"}, "requires exactly one"),
-            ({"scope": "collection", "mean": mean, "path": "mean.npy"}, "requires exactly one"),
+            ({"scope": "collection", "mean": mean, "path": "mean.safetensors"}, "requires exactly one"),
             ({"scope": "document", "mean": mean}, "only valid with collection scope"),
             ({"scope": "document", "invalid": True}, "unknown center setting"),
             ({"scope": "collection", "mean": [[0.0, 1.0]]}, "finite one-dimensional array"),
@@ -223,15 +225,17 @@ class TestPooling(unittest.TestCase):
 
         centered = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device, "modelargs": {"muvera": None, "center": True}})
         texts = ["Short text.", "A considerably longer text exercises padding behavior."]
-        separate = centered.encode(texts, batch=1, category="data")
+        self.assertEqual(centered.center, {"scope": "batch"})
         together = centered.encode(texts, batch=2, category="data")
-        np.testing.assert_allclose(separate, together, rtol=1e-5, atol=1e-6)
+        repeated = centered.encode(texts, batch=2, category="data")
+        np.testing.assert_array_equal(together, repeated)
+        self.assertEqual(centered.batches, [2])
         self.assertTrue(np.any(np.all(together == 0.0, axis=2)))
 
-        centered.center = {"scope": "batch"}
-        batch = centered.encode(texts, batch=1, category="data")
-        self.assertEqual(centered.batches, [1, 1])
-        np.testing.assert_allclose(batch, separate, rtol=1e-5, atol=1e-6)
+        centered.center = {"scope": "document"}
+        separate = centered.encode(texts, batch=1, category="data")
+        document = centered.encode(texts, batch=2, category="data")
+        np.testing.assert_allclose(document, separate, rtol=1e-5, atol=1e-6)
 
     def testLemur(self):
         """
@@ -285,6 +289,55 @@ class TestPooling(unittest.TestCase):
             # MUVERA remains the default when LEMUR is absent
             pooling = PoolingFactory.create({"path": model, "device": self.device})
             self.assertEqual(pooling.encode(["test"], category="query").shape, (1, 10240))
+
+    def testLemurCenter(self):
+        """
+        Test late pooling with centered LEMUR fixed dimensional encoding
+        """
+
+        corpus = [
+            "Machine learning models retrieve relevant passages.",
+            "Late interaction compares token embeddings.",
+            "Dense indexes search fixed dimensional vectors.",
+            "A query encoder produces contextual token vectors.",
+            "Document encoders represent passages for retrieval.",
+            "Maximum similarity aggregates token matches.",
+            "LEMUR learns a corpus specific reduction.",
+            "MUVERA uses randomized fixed dimensional encodings.",
+            "The trainer stores reusable pooling artifacts.",
+            "New documents can be encoded after training.",
+            "Short text.",
+            "A considerably longer synthetic document exercises padding behavior.",
+        ] * 2
+        texts = ["Short text.", "A considerably longer synthetic document exercises padding behavior."]
+
+        for model in ["neuml/colbert-bert-tiny", "neuml/pylate-bert-tiny"]:
+            with tempfile.TemporaryDirectory() as output:
+                LemurTrainer()(
+                    model,
+                    corpus,
+                    output,
+                    gpu=False,
+                    epochs=0,
+                    final_hidden_dim=128,
+                    train_subset_size=24,
+                    learn_subset_size=256,
+                    ols_sample_size=128,
+                    seed=42,
+                )
+
+                pooling = PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"lemur": {"path": output}, "center": True}})
+                self.assertEqual(pooling.center, {"scope": "batch"})
+
+                queries = pooling.encode(texts, batch=2, category="query")
+                documents = pooling.encode(texts, batch=2, category="data")
+                self.assertEqual(queries.shape, (2, 128))
+                self.assertEqual(documents.shape, (2, 128))
+                self.assertTrue(np.isfinite(queries).all())
+                self.assertTrue(np.isfinite(documents).all())
+
+                np.testing.assert_array_equal(pooling.encode(texts, batch=2, category="query"), queries)
+                np.testing.assert_array_equal(pooling.encode(texts, batch=2, category="data"), documents)
 
     def testLemurRoundTrip(self):
         """

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -235,7 +235,7 @@ class TestPooling(unittest.TestCase):
         centered.center = {"scope": "document"}
         separate = centered.encode(texts, batch=1, category="data")
         document = centered.encode(texts, batch=2, category="data")
-        np.testing.assert_allclose(document, separate, rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(document, separate, rtol=1e-4, atol=1e-5)
 
     def testLemur(self):
         """
@@ -284,7 +284,7 @@ class TestPooling(unittest.TestCase):
 
                 # LEMUR must use true token counts, independent of batch padding
                 singles = np.vstack([pooling.encode([text], category="data") for text in texts])
-                np.testing.assert_allclose(documents, singles, rtol=1e-5, atol=1e-6)
+                np.testing.assert_allclose(documents, singles, rtol=1e-4, atol=1e-5)
 
             # MUVERA remains the default when LEMUR is absent
             pooling = PoolingFactory.create({"path": model, "device": self.device})

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -2,6 +2,8 @@
 Pooling module tests
 """
 
+# pylint: disable=too-many-public-methods
+
 import json
 import os
 import tempfile
@@ -10,7 +12,7 @@ import unittest
 import numpy as np
 import torch
 
-from txtai.models import Models, ClsPooling, LastPooling, Lemur, MeanPooling, PoolingFactory
+from txtai.models import Models, ClsPooling, LastPooling, LatePooling, Lemur, MeanPooling, PoolingFactory
 from txtai.models.pooling.lemur import Activation
 from txtai.pipeline import LemurTrainer
 
@@ -110,6 +112,126 @@ class TestPooling(unittest.TestCase):
                 {"path": model, "device": self.device, "modelargs": {"muvera": {"repetitions": 5, "hashes": 2, "projection": 8}}}
             )
             self.assertEqual(pooling.encode(["test"], category="data").shape, (1, 160))
+
+    def testLateCenterDefaults(self):
+        """
+        Test late pooling token centering defaults
+        """
+
+        empty = torch.nn.Sequential()
+        single = torch.nn.Sequential(torch.nn.Linear(2, 2, bias=False))
+        multiple = torch.nn.Sequential(torch.nn.Sequential(torch.nn.Linear(2, 2, bias=False), torch.nn.Linear(2, 2, bias=False)))
+
+        self.assertIsNone(LatePooling.centersettings(None, empty, False))
+        self.assertIsNone(LatePooling.centersettings(None, single, False))
+        self.assertEqual(LatePooling.centersettings(None, multiple, False), {"scope": "document"})
+        self.assertIsNone(LatePooling.centersettings(False, multiple, True))
+        self.assertEqual(LatePooling.centersettings(True, empty, True), {"scope": "document"})
+        self.assertEqual(LatePooling.centersettings({"scope": "batch"}, empty, True), {"scope": "batch"})
+
+    def testLateCenterSettings(self):
+        """
+        Test late pooling token centering settings
+        """
+
+        linear = torch.nn.Sequential()
+        mean = np.array([0.25, -0.25], dtype=np.float32)
+        settings = LatePooling.centersettings({"scope": "collection", "mean": mean.tolist()}, linear, True)
+        np.testing.assert_array_equal(settings["mean"], mean)
+
+        with tempfile.TemporaryDirectory() as output:
+            path = os.path.join(output, "mean.npy")
+            np.save(path, mean)
+            settings = LatePooling.centersettings({"scope": "collection", "path": path}, linear, True)
+            np.testing.assert_array_equal(settings["mean"], mean)
+
+        tests = [
+            (None, "center must be a boolean or dictionary"),
+            ({"scope": "invalid"}, "center scope must be one of"),
+            ({"scope": "collection"}, "requires exactly one"),
+            ({"scope": "collection", "mean": mean, "path": "mean.npy"}, "requires exactly one"),
+            ({"scope": "document", "mean": mean}, "only valid with collection scope"),
+            ({"scope": "document", "invalid": True}, "unknown center setting"),
+            ({"scope": "collection", "mean": [[0.0, 1.0]]}, "finite one-dimensional array"),
+        ]
+
+        for center, message in tests:
+            with self.subTest(center=center):
+                with self.assertRaisesRegex(ValueError, message):
+                    LatePooling.centersettings(center, linear, True)
+
+    def testLateCenterScopes(self):
+        """
+        Test document, batch and collection token centering
+        """
+
+        data = np.array(
+            [
+                [[1.0, 0.0], [0.0, 1.0], [0.0, 0.0]],
+                [[1.0, 0.0], [-1.0, 0.0], [0.0, 0.0]],
+            ],
+            dtype=np.float32,
+        )
+
+        outputs = {}
+        for scope in ("document", "batch", "collection"):
+            pooling = LatePooling.__new__(LatePooling)
+            object.__setattr__(pooling, "center", {"scope": scope, "mean": np.array([0.25, 0.25])} if scope == "collection" else {"scope": scope})
+            outputs[scope] = pooling.centerdata(data)
+
+            np.testing.assert_array_equal(outputs[scope][:, 2], np.zeros((2, 2), dtype=np.float32))
+            norms = np.linalg.norm(outputs[scope][:, :2], axis=2)
+            self.assertTrue(np.all((norms == 0.0) | np.isclose(norms, 1.0)))
+
+        self.assertFalse(np.array_equal(outputs["document"], outputs["batch"]))
+        self.assertFalse(np.array_equal(outputs["batch"], outputs["collection"]))
+
+        # Document centering is batch-independent and equals batch centering for one item
+        pooling = LatePooling.__new__(LatePooling)
+        object.__setattr__(pooling, "center", {"scope": "document"})
+        separate = np.vstack([pooling.centerdata(data[x : x + 1]) for x in range(len(data))])
+        np.testing.assert_array_equal(outputs["document"], separate)
+
+        object.__setattr__(pooling, "center", {"scope": "batch"})
+        object.__setattr__(pooling, "batches", [1, 1])
+        for x in range(len(data)):
+            np.testing.assert_array_equal(pooling.centerdata(data[x : x + 1]), outputs["document"][x : x + 1])
+        np.testing.assert_array_equal(pooling.centerdata(data), outputs["document"])
+
+        object.__setattr__(pooling, "center", {"scope": "document"})
+        object.__setattr__(pooling, "encoder", None)
+        object.__setattr__(pooling, "lengths", [2, 2])
+        query = pooling.postencode([value.copy() for value in data[:, :2]], "query")
+        documents = pooling.postencode([value.copy() for value in data[:, :2]], "data")
+        np.testing.assert_array_equal(query, documents)
+
+        object.__setattr__(pooling, "center", {"scope": "collection", "mean": np.zeros(3)})
+        with self.assertRaisesRegex(ValueError, "dimension must match"):
+            pooling.centerdata(data)
+
+    def testLateCenterDisabled(self):
+        """
+        Test omitted and explicitly disabled centering are byte-identical
+        """
+
+        base = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device, "modelargs": {"muvera": None}})
+        disabled = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device, "modelargs": {"muvera": None, "center": False}})
+
+        self.assertIsNone(base.center)
+        self.assertIsNone(disabled.center)
+        np.testing.assert_array_equal(base.encode(["test"], category="query"), disabled.encode(["test"], category="query"))
+
+        centered = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device, "modelargs": {"muvera": None, "center": True}})
+        texts = ["Short text.", "A considerably longer text exercises padding behavior."]
+        separate = centered.encode(texts, batch=1, category="data")
+        together = centered.encode(texts, batch=2, category="data")
+        np.testing.assert_allclose(separate, together, rtol=1e-5, atol=1e-6)
+        self.assertTrue(np.any(np.all(together == 0.0, axis=2)))
+
+        centered.center = {"scope": "batch"}
+        batch = centered.encode(texts, batch=1, category="data")
+        self.assertEqual(centered.batches, [1, 1])
+        np.testing.assert_allclose(batch, separate, rtol=1e-5, atol=1e-6)
 
     def testLemur(self):
         """

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -272,7 +272,7 @@ class TestPooling(unittest.TestCase):
                     seed=42,
                 )
 
-                pooling = PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"lemur": {"path": output}}})
+                pooling = PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"lemur": {"path": output}, "center": False}})
                 texts = ["Short text.", "A considerably longer synthetic document exercises padding behavior."]
                 queries = pooling.encode(texts, category="query")
                 documents = pooling.encode(texts, category="data")


### PR DESCRIPTION
Follows the centering discussion on #1164.

Adds configurable mean centering to `LatePooling` through `modelargs.center`, applied to normalized real token rows before MUVERA or LEMUR for both queries and documents. Each scope subtracts its mean, normalizes real rows again, and leaves zero padding unchanged. `true` selects document scope, `false` disables centering, and the dictionary form supports `document`, `batch`, and `collection`; when the key is omitted, centering defaults on only when the loaded dense stack contains more than one `torch.nn.Linear`, leaving zero- and one-linear models unchanged.

### Default heuristic

| Model | Loaded linear layers | Collection-centering evidence (NDCG@10) | Omitted default |
|---|---:|---|---|
| `lightonai/LateOn` | 5 | LEMUR: nfcorpus 0.00000 → 0.31473; scifact 0.04985 → 0.68624 | on |
| `colbert-ir/colbertv2.0` | 1 | MUVERA: nfcorpus −0.05305; scifact −0.05781. LEMUR: +0.02293 / −0.00070 | off |

### Mean scope comparison

Base LateOn NDCG@10:

| Dataset | Encoder | Document | Batch (32) | Collection |
|---|---|---:|---:|---:|
| nfcorpus | LEMUR-2048 | 0.29501 | 0.33309 | 0.31473 |
| nfcorpus | MUVERA-10240 | 0.11463 | 0.18382 | 0.13369 |
| scifact | LEMUR-2048 | 0.68672 | 0.69016 | 0.68624 |
| scifact | MUVERA-10240 | 0.33552 | 0.37252 | 0.29293 |

Batch is now the default for `center: true` per review; it was stronger in all four measured cells, at the cost of making output depend on batch composition. Document scope remains available through the dictionary form for deterministic, batch-independent output.

Collection scope requires a caller-provided one-dimensional mean through an array-like `mean` or NumPy `.npy` `path`. This does not add a corpus pass or stored-mean index integration; I can follow up with that integration if wanted.

`lightonai/LateOn-regularized` still underperformed after centering and stays out of scope here.

Tests: the focused 4-test centering run and full 21-test pooling module pass locally, the torch-blocked minimal-import probe passes on the branch and base control, and the fork `build` and `minimal` workflows are green.
