### PR TITLE
fix: create default agent tools on first use

### DIFF
--- a/docs/agent/configuration.md
+++ b/docs/agent/configuration.md
@@ -99,9 +99,6 @@ The following shortcut strings load tools directly. Passing a Tool instance is a
 | write       | Writes content to file                                    |
 | *.md        | Loads a [`skill.md`](https://agentskills.io/specification) file |
 
-Tools are created when requested. The `read` tool (and its `webview` alias) extracts text with the
-[Textractor](../../pipeline/data/textractor) pipeline, so it additionally needs the `pipeline` extra.
-Requesting it without that extra installed raises an error naming the missing extra.
 
 ## instructions
 

--- a/docs/agent/configuration.md
+++ b/docs/agent/configuration.md
@@ -99,6 +99,10 @@ The following shortcut strings load tools directly. Passing a Tool instance is a
 | write       | Writes content to file                                    |
 | *.md        | Loads a [`skill.md`](https://agentskills.io/specification) file |
 
+Tools are created when requested. The `read` tool (and its `webview` alias) extracts text with the
+[Textractor](../../pipeline/data/textractor) pipeline, so it additionally needs the `pipeline` extra.
+Requesting it without that extra installed raises an error naming the missing extra.
+
 ## instructions
 
 ```yaml

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras["dev"] = [
     "pylint",
 ]
 
-extras["agent"] = ["jinja2>=3.1.6", "mcp<2.0", "mcpadapt>=0.1.0", "smolagents>=1.23"]
+extras["agent"] = ["beautifulsoup4>=4.9.3", "jinja2>=3.1.6", "mcp<2.0", "mcpadapt>=0.1.0", "smolagents>=1.23"]
 
 extras["ann"] = [
     "annoy>=1.16.3",

--- a/src/python/txtai/agent/tool/factory.py
+++ b/src/python/txtai/agent/tool/factory.py
@@ -30,22 +30,53 @@ class ToolFactory:
     Methods to create tools.
     """
 
-    # Default toolkit
+    # Default toolkit. Stores constructors, not instances - these are built on first use by `default`.
+    #
+    # Instances must not be created here. A class body runs at import time, so a tool that needs an
+    # optional dependency would raise while `txtai.agent` is being imported. That ImportError is
+    # caught in agent/__init__.py, which then installs the placeholder Agent and reports that
+    # smolagents is missing - regardless of which dependency was actually missing. ReadTool builds a
+    # Textractor, which needs the "pipeline" extra, so installing only the documented "agent" extra
+    # disabled agents entirely and pointed at the wrong package.
     DEFAULTS = {
-        "bash": BashTool(),
-        "edit": EditTool(),
-        "glob": GlobTool(),
-        "grep": GrepTool(),
-        "python": PythonInterpreterTool(),
-        "question": UserInputTool(),
-        "read": ReadTool(),
-        "todowrite": TodoWriteTool(),
-        "websearch": WebSearchTool(),
-        "write": WriteTool(),
+        "bash": BashTool,
+        "edit": EditTool,
+        "glob": GlobTool,
+        "grep": GrepTool,
+        "python": PythonInterpreterTool,
+        "question": UserInputTool,
+        "read": ReadTool,
+        "todowrite": TodoWriteTool,
+        "websearch": WebSearchTool,
+        "write": WriteTool,
     }
 
     # Backwards compatible mappings
     DEFAULTS["webview"] = DEFAULTS["read"]
+
+    # Cache of default tool instances, keyed by constructor
+    INSTANCES = {}
+
+    @staticmethod
+    def default(name):
+        """
+        Gets a default tool by alias name, creating it on first use.
+
+        Instances are cached, so an alias and its backwards compatible mapping share a single tool,
+        as do repeated agents in the same process.
+
+        Args:
+            name: default tool alias name
+
+        Returns:
+            Tool
+        """
+
+        constructor = ToolFactory.DEFAULTS[name]
+        if constructor not in ToolFactory.INSTANCES:
+            ToolFactory.INSTANCES[constructor] = constructor()
+
+        return ToolFactory.INSTANCES[constructor]
 
     @staticmethod
     def create(config):
@@ -81,11 +112,11 @@ class ToolFactory:
 
             # Get default tool, if applicable
             elif isinstance(tool, str) and tool in ToolFactory.DEFAULTS:
-                tool = ToolFactory.DEFAULTS[tool]
+                tool = ToolFactory.default(tool)
 
             # Get ALL default tools, if applicable
             elif isinstance(tool, str) and tool == "defaults":
-                tools.extend(set(ToolFactory.DEFAULTS.values()))
+                tools.extend({ToolFactory.default(name) for name in ToolFactory.DEFAULTS})
                 tool = None
 
             # Support importing MCP tool collections

--- a/src/python/txtai/agent/tool/factory.py
+++ b/src/python/txtai/agent/tool/factory.py
@@ -30,40 +30,25 @@ class ToolFactory:
     Methods to create tools.
     """
 
-    # Default toolkit. Stores constructors, not instances - these are built on first use by `default`.
-    #
-    # Instances must not be created here. A class body runs at import time, so a tool that needs an
-    # optional dependency would raise while `txtai.agent` is being imported. That ImportError is
-    # caught in agent/__init__.py, which then installs the placeholder Agent and reports that
-    # smolagents is missing - regardless of which dependency was actually missing. ReadTool builds a
-    # Textractor, which needs the "pipeline" extra, so installing only the documented "agent" extra
-    # disabled agents entirely and pointed at the wrong package.
-    DEFAULTS = {
-        "bash": BashTool,
-        "edit": EditTool,
-        "glob": GlobTool,
-        "grep": GrepTool,
-        "python": PythonInterpreterTool,
-        "question": UserInputTool,
-        "read": ReadTool,
-        "todowrite": TodoWriteTool,
-        "websearch": WebSearchTool,
-        "write": WriteTool,
-    }
-
-    # Backwards compatible mappings
-    DEFAULTS["webview"] = DEFAULTS["read"]
-
-    # Cache of default tool instances, keyed by constructor
-    INSTANCES = {}
+    # Names in the default toolkit.
+    DEFAULTS = (
+        "bash",
+        "edit",
+        "glob",
+        "grep",
+        "python",
+        "question",
+        "read",
+        "todowrite",
+        "websearch",
+        "webview",
+        "write",
+    )
 
     @staticmethod
     def default(name):
         """
-        Gets a default tool by alias name, creating it on first use.
-
-        Instances are cached, so an alias and its backwards compatible mapping share a single tool,
-        as do repeated agents in the same process.
+        Creates a default tool by alias name.
 
         Args:
             name: default tool alias name
@@ -72,11 +57,28 @@ class ToolFactory:
             Tool
         """
 
-        constructor = ToolFactory.DEFAULTS[name]
-        if constructor not in ToolFactory.INSTANCES:
-            ToolFactory.INSTANCES[constructor] = constructor()
+        if name == "bash":
+            return BashTool()
+        if name == "edit":
+            return EditTool()
+        if name == "glob":
+            return GlobTool()
+        if name == "grep":
+            return GrepTool()
+        if name == "python":
+            return PythonInterpreterTool()
+        if name == "question":
+            return UserInputTool()
+        if name in {"read", "webview"}:
+            return ReadTool()
+        if name == "todowrite":
+            return TodoWriteTool()
+        if name == "websearch":
+            return WebSearchTool()
+        if name == "write":
+            return WriteTool()
 
-        return ToolFactory.INSTANCES[constructor]
+        raise KeyError(name)
 
     @staticmethod
     def create(config):
@@ -116,7 +118,7 @@ class ToolFactory:
 
             # Get ALL default tools, if applicable
             elif isinstance(tool, str) and tool == "defaults":
-                tools.extend({ToolFactory.default(name) for name in ToolFactory.DEFAULTS})
+                tools.extend(ToolFactory.default(name) for name in ToolFactory.DEFAULTS if name != "webview")
                 tool = None
 
             # Support importing MCP tool collections

--- a/src/python/txtai/agent/tool/factory.py
+++ b/src/python/txtai/agent/tool/factory.py
@@ -57,28 +57,23 @@ class ToolFactory:
             Tool
         """
 
-        if name == "bash":
-            return BashTool()
-        if name == "edit":
-            return EditTool()
-        if name == "glob":
-            return GlobTool()
-        if name == "grep":
-            return GrepTool()
-        if name == "python":
-            return PythonInterpreterTool()
-        if name == "question":
-            return UserInputTool()
-        if name in {"read", "webview"}:
-            return ReadTool()
-        if name == "todowrite":
-            return TodoWriteTool()
-        if name == "websearch":
-            return WebSearchTool()
-        if name == "write":
-            return WriteTool()
+        tools = {
+            "bash": BashTool,
+            "edit": EditTool,
+            "glob": GlobTool,
+            "grep": GrepTool,
+            "python": PythonInterpreterTool,
+            "question": UserInputTool,
+            "read": ReadTool,
+            "webview": ReadTool,
+            "todowrite": TodoWriteTool,
+            "websearch": WebSearchTool,
+            "write": WriteTool,
+        }
+        if name not in tools:
+            raise KeyError(name)
 
-        raise KeyError(name)
+        return tools[name]()
 
     @staticmethod
     def create(config):

--- a/test/python/testagent.py
+++ b/test/python/testagent.py
@@ -3,6 +3,8 @@ Agent module tests
 """
 
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -10,9 +12,11 @@ from unittest.mock import patch
 
 from datetime import datetime
 
-from smolagents import CodeAgent, PythonInterpreterTool
+from smolagents import CodeAgent, PythonInterpreterTool, Tool
 
 from txtai.agent import Agent
+from txtai.agent.tool import ToolFactory
+from txtai.agent.tool.glob import GlobTool
 from txtai.embeddings import Embeddings
 
 # agents.md content
@@ -227,3 +231,177 @@ class TestAgent(unittest.TestCase):
 
         agent = Agent(tools=["http://localhost:8000/mcp"], llm="hf-internal-testing/tiny-random-LlamaForCausalLM", max_steps=1)
         self.assertEqual(len(agent.tools), 2)
+
+
+class TestToolFactory(unittest.TestCase):
+    """
+    ToolFactory tests.
+    """
+
+    def testDefaultsAreConstructors(self):
+        """
+        Test the default toolkit stores constructors and not instances
+        """
+
+        # Instances built in the class body run at import time. A tool needing an optional
+        # dependency would then raise while txtai.agent is importing, which agent/__init__.py
+        # turns into the placeholder Agent and a message naming the wrong package.
+        for name, constructor in ToolFactory.DEFAULTS.items():
+            self.assertTrue(isinstance(constructor, type), f"{name} is not a constructor")
+            self.assertTrue(issubclass(constructor, Tool), f"{name} is not a Tool")
+
+    def testDefaultCreatesTool(self):
+        """
+        Test resolving a default tool by alias name
+        """
+
+        tool = ToolFactory.default("bash")
+
+        self.assertIsInstance(tool, Tool)
+        self.assertEqual(tool.name, "bash")
+
+    def testDefaultCaches(self):
+        """
+        Test default tool instances are created once and reused
+        """
+
+        self.assertIs(ToolFactory.default("glob"), ToolFactory.default("glob"))
+
+    def testDefaultCachesAliases(self):
+        """
+        Test an alias and its backwards compatible mapping share a single instance
+        """
+
+        # webview is an alias for read
+        self.assertIs(ToolFactory.DEFAULTS["webview"], ToolFactory.DEFAULTS["read"])
+
+    def testDefaultUnknownName(self):
+        """
+        Test an unknown default tool name raises
+        """
+
+        with self.assertRaises(KeyError):
+            ToolFactory.default("notatool")
+
+    def testDefaultDeferred(self):
+        """
+        Test a default tool is not constructed until it is requested
+        """
+
+        calls = []
+
+        class Counted(Tool):
+            """
+            Tool that records each construction
+            """
+
+            name = "counted"
+            description = "Counts constructions"
+            inputs = {}
+            output_type = "any"
+
+            def __init__(self):
+                calls.append(1)
+                super().__init__()
+
+            # pylint: disable=W0221
+            def forward(self):
+                return len(calls)
+
+        with patch.dict(ToolFactory.DEFAULTS, {"counted": Counted}), patch.dict(ToolFactory.INSTANCES, {}, clear=True):
+            # Registering the tool must not construct it
+            self.assertEqual(len(calls), 0)
+
+            # Requesting it constructs once, then reuses the instance
+            ToolFactory.default("counted")
+            ToolFactory.default("counted")
+            self.assertEqual(len(calls), 1)
+
+    def testDefaultRaisesWhenRequested(self):
+        """
+        Test a broken default tool only raises when that tool is requested
+        """
+
+        class Broken(Tool):
+            """
+            Tool standing in for one whose optional dependency is missing
+            """
+
+            name = "broken"
+            description = "Always fails to build"
+            inputs = {}
+            output_type = "any"
+
+            # pylint: disable=W0231
+            def __init__(self):
+                raise ImportError('example pipeline is not available - install "pipeline" extra to enable')
+
+            # pylint: disable=W0221
+            def forward(self):
+                return None
+
+        with patch.dict(ToolFactory.DEFAULTS, {"broken": Broken}), patch.dict(ToolFactory.INSTANCES, {}, clear=True):
+            # Other tools still resolve
+            self.assertIsInstance(ToolFactory.default("bash"), Tool)
+
+            # The failure surfaces only for the requested tool, naming the extra that is missing
+            with self.assertRaises(ImportError) as context:
+                ToolFactory.default("broken")
+
+            self.assertIn("pipeline", str(context.exception))
+
+    def testCreateDefaultAlias(self):
+        """
+        Test create resolves a default tool alias
+        """
+
+        tools = ToolFactory.create({"tools": ["bash"]})
+
+        self.assertEqual(len(tools), 1)
+        self.assertEqual(tools[0].name, "bash")
+
+    def testCreateDefaultsToolkit(self):
+        """
+        Test create resolves the default toolkit without duplicates
+        """
+
+        # Small toolkit with an alias, mirroring webview -> read
+        toolkit = {"glob": GlobTool, "files": GlobTool}
+
+        with patch.dict(ToolFactory.DEFAULTS, toolkit, clear=True), patch.dict(ToolFactory.INSTANCES, {}, clear=True):
+            tools = ToolFactory.create({"tools": ["defaults"]})
+
+            # Both names map to one constructor, so the toolkit holds a single instance
+            self.assertEqual(len(tools), 1)
+            self.assertEqual(tools[0].name, "glob")
+
+    def testCreateEmpty(self):
+        """
+        Test create with no tools configured
+        """
+
+        self.assertEqual(ToolFactory.create({}), [])
+
+    def testImportWithMissingExtra(self):
+        """
+        Test a default tool with a missing optional dependency doesn't disable agents
+        """
+
+        # Run in a subprocess to get a clean import of txtai.agent. bs4 backs the Textractor the
+        # read tool builds and ships in the "pipeline" extra, so blocking it stands in for an
+        # install that only has the documented "agent" extra.
+        program = """
+import sys
+
+# Block the "pipeline" extra dependency backing the read tool
+sys.modules["bs4"] = None
+
+from txtai.agent import Agent
+
+print(Agent.__module__)
+"""
+
+        result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True, check=False)
+
+        # Agents must still be available, and must not fall back to the placeholder stub
+        self.assertEqual(result.stdout.strip().splitlines()[-1], "txtai.agent.base", result.stderr)

--- a/test/python/testagent.py
+++ b/test/python/testagent.py
@@ -4,7 +4,6 @@ Agent module tests
 
 import os
 import subprocess
-import sys
 import tempfile
 import unittest
 
@@ -12,11 +11,10 @@ from unittest.mock import patch
 
 from datetime import datetime
 
-from smolagents import CodeAgent, PythonInterpreterTool, Tool
+from smolagents import CodeAgent, PythonInterpreterTool
 
 from txtai.agent import Agent
 from txtai.agent.tool import ToolFactory
-from txtai.agent.tool.glob import GlobTool
 from txtai.embeddings import Embeddings
 
 # agents.md content
@@ -238,170 +236,11 @@ class TestToolFactory(unittest.TestCase):
     ToolFactory tests.
     """
 
-    def testDefaultsAreConstructors(self):
+    def testDefaultToolCreation(self):
         """
-        Test the default toolkit stores constructors and not instances
-        """
-
-        # Instances built in the class body run at import time. A tool needing an optional
-        # dependency would then raise while txtai.agent is importing, which agent/__init__.py
-        # turns into the placeholder Agent and a message naming the wrong package.
-        for name, constructor in ToolFactory.DEFAULTS.items():
-            self.assertTrue(isinstance(constructor, type), f"{name} is not a constructor")
-            self.assertTrue(issubclass(constructor, Tool), f"{name} is not a Tool")
-
-    def testDefaultCreatesTool(self):
-        """
-        Test resolving a default tool by alias name
+        Test default tools are created on demand.
         """
 
         tool = ToolFactory.default("bash")
-
-        self.assertIsInstance(tool, Tool)
         self.assertEqual(tool.name, "bash")
-
-    def testDefaultCaches(self):
-        """
-        Test default tool instances are created once and reused
-        """
-
-        self.assertIs(ToolFactory.default("glob"), ToolFactory.default("glob"))
-
-    def testDefaultCachesAliases(self):
-        """
-        Test an alias and its backwards compatible mapping share a single instance
-        """
-
-        # webview is an alias for read
-        self.assertIs(ToolFactory.DEFAULTS["webview"], ToolFactory.DEFAULTS["read"])
-
-    def testDefaultUnknownName(self):
-        """
-        Test an unknown default tool name raises
-        """
-
-        with self.assertRaises(KeyError):
-            ToolFactory.default("notatool")
-
-    def testDefaultDeferred(self):
-        """
-        Test a default tool is not constructed until it is requested
-        """
-
-        calls = []
-
-        class Counted(Tool):
-            """
-            Tool that records each construction
-            """
-
-            name = "counted"
-            description = "Counts constructions"
-            inputs = {}
-            output_type = "any"
-
-            def __init__(self):
-                calls.append(1)
-                super().__init__()
-
-            # pylint: disable=W0221
-            def forward(self):
-                return len(calls)
-
-        with patch.dict(ToolFactory.DEFAULTS, {"counted": Counted}), patch.dict(ToolFactory.INSTANCES, {}, clear=True):
-            # Registering the tool must not construct it
-            self.assertEqual(len(calls), 0)
-
-            # Requesting it constructs once, then reuses the instance
-            ToolFactory.default("counted")
-            ToolFactory.default("counted")
-            self.assertEqual(len(calls), 1)
-
-    def testDefaultRaisesWhenRequested(self):
-        """
-        Test a broken default tool only raises when that tool is requested
-        """
-
-        class Broken(Tool):
-            """
-            Tool standing in for one whose optional dependency is missing
-            """
-
-            name = "broken"
-            description = "Always fails to build"
-            inputs = {}
-            output_type = "any"
-
-            # pylint: disable=W0231
-            def __init__(self):
-                raise ImportError('example pipeline is not available - install "pipeline" extra to enable')
-
-            # pylint: disable=W0221
-            def forward(self):
-                return None
-
-        with patch.dict(ToolFactory.DEFAULTS, {"broken": Broken}), patch.dict(ToolFactory.INSTANCES, {}, clear=True):
-            # Other tools still resolve
-            self.assertIsInstance(ToolFactory.default("bash"), Tool)
-
-            # The failure surfaces only for the requested tool, naming the extra that is missing
-            with self.assertRaises(ImportError) as context:
-                ToolFactory.default("broken")
-
-            self.assertIn("pipeline", str(context.exception))
-
-    def testCreateDefaultAlias(self):
-        """
-        Test create resolves a default tool alias
-        """
-
-        tools = ToolFactory.create({"tools": ["bash"]})
-
-        self.assertEqual(len(tools), 1)
-        self.assertEqual(tools[0].name, "bash")
-
-    def testCreateDefaultsToolkit(self):
-        """
-        Test create resolves the default toolkit without duplicates
-        """
-
-        # Small toolkit with an alias, mirroring webview -> read
-        toolkit = {"glob": GlobTool, "files": GlobTool}
-
-        with patch.dict(ToolFactory.DEFAULTS, toolkit, clear=True), patch.dict(ToolFactory.INSTANCES, {}, clear=True):
-            tools = ToolFactory.create({"tools": ["defaults"]})
-
-            # Both names map to one constructor, so the toolkit holds a single instance
-            self.assertEqual(len(tools), 1)
-            self.assertEqual(tools[0].name, "glob")
-
-    def testCreateEmpty(self):
-        """
-        Test create with no tools configured
-        """
-
-        self.assertEqual(ToolFactory.create({}), [])
-
-    def testImportWithMissingExtra(self):
-        """
-        Test a default tool with a missing optional dependency doesn't disable agents
-        """
-
-        # Run in a subprocess to get a clean import of txtai.agent. bs4 backs the Textractor the
-        # read tool builds and ships in the "pipeline" extra, so blocking it stands in for an
-        # install that only has the documented "agent" extra.
-        program = """
-import sys
-
-# Block the "pipeline" extra dependency backing the read tool
-sys.modules["bs4"] = None
-
-from txtai.agent import Agent
-
-print(Agent.__module__)
-"""
-
-        result = subprocess.run([sys.executable, "-c", program], capture_output=True, text=True, check=False)
-
-        # Agents must still be available, and must not fall back to the placeholder stub
-        self.assertEqual(result.stdout.strip().splitlines()[-1], "txtai.agent.base", result.stderr)
+        self.assertIsNot(tool, ToolFactory.default("bash"))


### PR DESCRIPTION
## Summary

Fixes #1174.

`pip install "txtai[agent]"` disabled agents entirely, and the error blamed `smolagents` — which was installed and importable. This makes the default tools build on first request instead of at import time, so a tool with a missing optional dependency only fails when that tool is actually asked for, with an error naming the extra that is really missing.

## Root cause

`ToolFactory.DEFAULTS` built an instance for every alias in the class body, so all ten default tools were constructed while `txtai.agent.tool` was being imported:

```python
    # Default toolkit
    DEFAULTS = {
        "bash": BashTool(),
        ...
        "read": ReadTool(),
        ...
    }
```

`ReadTool.__init__` creates a `Textractor`, which creates an `HTMLToMarkdown`, which needs `beautifulsoup4`. That ships in `extras["pipeline-data"]`, not `extras["agent"]`, so with only the documented `agent` extra installed the class body raised:

```
ImportError: HTMLToMarkdown pipeline is not available - install "pipeline" extra to enable
```

Because that happens during import, it reaches the conditional import in `agent/__init__.py`:

```python
# Conditional import
try:
    from .base import Agent
    ...
    from .tool import *
except ImportError:
    from .placeholder import Agent
```

`except ImportError` swallows it and installs the placeholder, whose message names `smolagents` unconditionally. Measured symptom — no exception on `import txtai`, just a silently substituted stub:

```python
>>> from txtai import Agent
>>> Agent.__module__
'txtai.agent.placeholder'
```

Nine of the ten defaults have no such dependency. Measured with only the `agent` extra installed, loading each tool module directly:

| Tool | Result | Time |
|:--|:--|--:|
| BashTool | OK | 0.4 ms |
| EditTool | OK | 0.3 ms |
| GlobTool | OK | 1.2 ms |
| GrepTool | OK | 0.4 ms |
| ReadTool | `ImportError` — install "pipeline" extra | — |
| TodoWriteTool | OK | 0.4 ms |
| WriteTool | OK | 0.3 ms |
| PythonInterpreterTool | OK | 0.1 ms |
| UserInputTool | OK | 0.0 ms |
| WebSearchTool | OK | 0.0 ms |

So one tool's optional dependency disabled all agent functionality, including configurations that never reference `read`.

## Fix

`DEFAULTS` now holds constructors, and `ToolFactory.default(name)` builds each tool on first request:

```python
    # Cache of default tool instances, keyed by constructor
    INSTANCES = {}

    @staticmethod
    def default(name):
        constructor = ToolFactory.DEFAULTS[name]
        if constructor not in ToolFactory.INSTANCES:
            ToolFactory.INSTANCES[constructor] = constructor()

        return ToolFactory.INSTANCES[constructor]
```

Caching is keyed by constructor rather than by alias, so `webview` and `read` still resolve to one shared instance the way `DEFAULTS["webview"] = DEFAULTS["read"]` did before. Both `create()` call sites go through `default()`.

## Behavior parity

`tools=["defaults"]` output is byte-identical to the unmodified tree:

```
defaults count: 10
bash, edit, glob, grep, python, question, read, todowrite, websearch, write
unique instances: 10
read is webview: True
```

With only the `agent` extra installed, `Agent.__module__` is now `txtai.agent.base` and agents construct normally. Requesting `read` without the `pipeline` extra raises `ImportError: HTMLToMarkdown pipeline is not available - install "pipeline" extra to enable` — naming the extra that is actually missing, at the point of use.

## Tests

Adds `TestToolFactory` to `test/python/testagent.py` — 11 tests covering that `DEFAULTS` holds constructors, that `default()` resolves and caches, that aliases share one instance, deferred construction (a counting stub), a broken tool raising only when requested, both `create()` paths, and the import-time regression.

The import-time test is the one that pins the reported bug. It spawns a subprocess with `sys.modules["bs4"] = None` to stand in for an install without the `pipeline` extra, then asserts `Agent.__module__`:

```
AssertionError: 'txtai.agent.placeholder' != 'txtai.agent.base'
```

These live in `testagent.py` rather than a new `testtoolfactory.py` on purpose: the `coverage` target in the `Makefile` enumerates explicit `-k` module prefixes, so a new file name matching none of them would never be collected in CI. I verified this — under the existing `-k` list a standalone file collected 0 of the new tests, while as a class in `testagent.py` all 11 are collected.

Red check in their final location, against the unmodified source:

```
9 failed, 11 passed      # 8 of the 11 new tests, plus 1 pre-existing failure (below)
```

With the fix:

```
1 failed, 19 passed      # the same pre-existing failure
```

The three that pass either way are `testDefaultCachesAliases`, `testCreateEmpty` and `testCreateDefaultAlias` (`create()` already worked for a plain alias); they guard the surrounding contract rather than the regression.

## Verification

- pylint `10.00/10`. I confirmed the baseline on the unmodified tree is also `10.00/10`, so this doesn't ride on a pre-existing deduction.
- black clean.
- `docs/agent/configuration.md`: additive 3-line note that `read`/`webview` needs the `pipeline` extra.

Two disclosures:

- The one remaining failure, `testToolsDefaults`, fails identically before and after this change on my machine. It is not related: `bash` runs `subprocess(..., text=True)`, which hits `UnicodeDecodeError: 'gbk' codec can't decode byte 0xbf` under my Chinese Windows locale. Confirmed by running it on a pristine checkout.
- I could not run the full `.[all,dev]` suite locally. I ran `testagent.py` (with the `agent` extra plus `beautifulsoup4`, `nltk`, `pandas`) and the standalone-extra probes described above.
