### PR TITLE
fix(muvera): consume true token rows instead of batch-padded ones

### DIFF
--- a/src/python/txtai/models/pooling/muvera.py
+++ b/src/python/txtai/models/pooling/muvera.py
@@ -27,6 +27,9 @@ class Muvera:
       - Python port of the original C++ code: https://github.com/sigridjineth/muvera-py
     """
 
+    # Signals LatePooling that this encoder must receive true, unpadded token rows
+    unpadded = True
+
     def __init__(self, repetitions=20, hashes=5, projection=16, seed=42):
         """
         Creates a Muvera instance.

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -113,6 +113,20 @@ class TestPooling(unittest.TestCase):
             )
             self.assertEqual(pooling.encode(["test"], category="data").shape, (1, 160))
 
+    def testMuveraPadding(self):
+        """
+        Test MUVERA vectors don't change with batch padding
+        """
+
+        pooling = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device})
+        texts = ["Short text.", "A considerably longer text exercises padding behavior."]
+
+        # The shorter text must encode the same alone as it does batched with a longer text
+        for category in ["query", "data"]:
+            alone = pooling.encode([texts[0]], category=category)
+            batched = pooling.encode(texts, batch=2, category=category)
+            self.assertTrue(np.allclose(alone[0], batched[0], atol=1e-4))
+
     def testLateCenterDefaults(self):
         """
         Test late pooling token centering defaults


### PR DESCRIPTION
## Problem

`Muvera` is handed token vectors **after** `LatePooling.postencode` has padded every
document out to the batch maximum, so a document's fixed dimensional encoding depends
on what else happens to be in its batch.

The padded rows are not inert. In `Muvera.__call__` a zero (or pad-token) row still
produces a simhash partition index, so it is counted in `counts` and — for the `data`
category, which converts partition sums to averages — it divides real token contributions
by an inflated count. For the `query` category the pad-token rows the model emits are not
even zero, so they are normalized and summed into the encoding directly.

`Lemur`, the sibling encoder added alongside this code path, already declares
`unpadded = True` for exactly this reason, and `LatePooling` already has the branch that
honors it (`forward`/`preencode`/`postencode` track true token counts and slice each
document back to its real length). `Muvera` has the same requirement but never declared it.

## Reproduction

```python
import numpy as np
from txtai.models.pooling.factory import PoolingFactory

texts = ["Short text.", "A considerably longer text that exercises padding behavior in the pooling layer."]

pooling = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": -1})

for category in ("data", "query"):
    alone = pooling.encode([texts[0]], category=category)
    batched = pooling.encode(texts, batch=2, category=category)
    print(category, float(np.abs(alone[0] - batched[0]).max()))
```

The same document, encoded alone versus batched with a longer one:

| category | `max abs diff` before | after |
|---|---|---|
| `data` | 0.62 | 8.0e-07 |
| `query` | 7.77 | 2.1e-06 |

The residual ~1e-6 is ordinary float32 batching noise from the transformer forward pass.

In practice this means indexing a corpus of variable-length documents produces vectors that
shift with batch composition, and a query encoded on its own does not land in the same space
as the same text encoded inside a batch.

## Fix

Declare `unpadded = True` on `Muvera`. That is the existing signal `LatePooling` checks, so
no new plumbing is needed — the encoder now receives true, unpadded token rows exactly as
`Lemur` does.

## Testing

Added `testMuveraPadding`, which asserts the shorter text encodes the same alone as it does
batched with a longer text, for both categories.

- On `master` the new test **fails** (`1 failed, 1 passed` for `-k Muvera`).
- With this change the full `test/python/testmodels/testpooling.py` suite passes:
  `16 passed, 13 subtests passed`.

Verified against a clean install of `master`
(`pip install git+https://github.com/neuml/txtai.git`, tree byte-identical to
`ea531b3`) on CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
