### PR TITLE
Fix OpenAI chat message selection

### DIFF
--- a/src/python/txtai/api/routers/openai.py
+++ b/src/python/txtai/api/routers/openai.py
@@ -44,8 +44,8 @@ def chat(
     # Build keyword arguments
     kwargs = {key: value for key, value in [("stream", stream), ("maxlength", max_completion_tokens)] if value}
 
-    # Get first message
-    message = messages[0]["content"]
+    # Get latest message
+    message = messages[-1]["content"]
 
     # Agent
     if model in application.get().agents:

--- a/test/python/testapi/testopenai.py
+++ b/test/python/testapi/testopenai.py
@@ -122,6 +122,24 @@ class TestOpenAI(unittest.TestCase):
 
         self.assertIsNotNone(response["choices"][0]["message"]["content"])
 
+    def testChatLatestMessage(self):
+        """
+        Test a chat completion with multiple messages
+        """
+
+        response = self.client.post(
+            "/v1/chat/completions",
+            json={
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant"},
+                    {"role": "user", "content": "Hello"},
+                ],
+                "model": "segmentation",
+            },
+        ).json()
+
+        self.assertEqual(response["choices"][0]["message"]["content"], "Hello")
+
     def testChatPipeline(self):
         """
         Test a chat completion with a pipeline


### PR DESCRIPTION
## Summary

- use the latest chat message when dispatching OpenAI-compatible requests to agents, embeddings search, non-LLM pipelines, and workflows
- keep the default LLM path unchanged so it still receives the full conversation
- add a regression test with a system message followed by the current user message

Fixes #1182

## Validation

- `black --check src/python/txtai/api/routers/openai.py test/python/testapi/testopenai.py`
- `pylint --rcfile=.pylintrc src/python/txtai/api/routers/openai.py test/python/testapi/testopenai.py` (10.00/10)
- `python -m py_compile src/python/txtai/api/routers/openai.py test/python/testapi/testopenai.py`
- isolated dispatch matrix covering agent, embeddings, pipeline, workflow, and unchanged full-message LLM behavior