### PR TITLE
docs: add OrcaRouter to the LLM API example notebook

### DIFF
--- a/examples/70_Getting_started_with_LLM_APIs.ipynb
+++ b/examples/70_Getting_started_with_LLM_APIs.ipynb
@@ -197,6 +197,14 @@
         "    #\n",
         "    # https://docs.voyageai.com/docs/embeddings\n",
         "    'TEXT_EMBEDDING_PATH': 'voyage/voyage-01',\n",
+        "  },\n",
+        "  'ORCAROUTER': {\n",
+        "    'IS_ENABLED': False,\n",
+        "    'ENV_VAR': ['ORCAROUTER_API_KEY'],\n",
+        "    # https://www.orcarouter.ai\n",
+        "    # OpenAI-compatible multi-model routing gateway - one key, one endpoint\n",
+        "    'LLM_MODEL_NAME': 'openai/openai/gpt-4o-mini',\n",
+        "    'API_BASE': 'https://api.orcarouter.ai/v1',\n",
         "  }\n",
         "}\n",
         "\n",
@@ -332,6 +340,21 @@
       },
       "source": [
         "Voyage AI provides only [top-notch embeddings](https://docs.voyageai.com/docs/introduction). While it doesn't offer [its LLM model](https://docs.voyageai.com/docs/embeddings), that doesn't diminish its offerings. The cool thing? Their embeddings are versatile and can be integrated into any model you choose. So, feel free to experiment and have fun with them! That's the beauty of this notebook - it's all about exploration and learning."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OrcaRouterIntro"
+      },
+      "source": [
+        "### OrcaRouter\n",
+        "\n",
+        "[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible multi-model routing gateway - one API key and one endpoint expose ~190 models from OpenAI, Anthropic, DeepSeek, Gemini and more, with automatic per-request routing. It also runs gateway-level, zero-trust security for AI agents on the same endpoint - screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.\n",
+        "\n",
+        "In the config above, set `IS_ENABLED: True` for `ORCAROUTER`; the notebook then routes the `openai/openai/gpt-4o-mini` model to OrcaRouter's `API_BASE` using `ORCAROUTER_API_KEY`. The leading `openai/` is litellm's provider tag, so OrcaRouter receives the fully-qualified `openai/gpt-4o-mini` model id. `openai/orcarouter/auto` is a handy alias that auto-routes each request to the best available model.\n",
+        "\n",
+        "This notebook primarily focuses on well-known online API models, so OrcaRouter is disabled by default - enable it when you want to try it."
       ]
     },
     {
@@ -710,14 +733,15 @@
         "]\n",
         "\n",
         "# https://neuml.github.io/txtai/pipeline/text/llm/\n",
-        "def runllm(prompt=\"\", path=None):\n",
+        "def runllm(prompt=\"\", path=None, api_base=None, api_key=None):\n",
         "  if path:\n",
         "    # A quick note: you can skip specifying the `method` argument.\n",
         "    # There's an autodetection logic designed to recognize it as a `litellm` model.\n",
         "    # \n",
         "    # llm = LLM(LLM_MODEL_NAME, method=\"litellm\")\n",
         "    # \n",
-        "    llm = LLM(path)\n",
+        "    # A custom OpenAI-compatible endpoint (e.g. OrcaRouter) can be set with `api_base` + `api_key`.\n",
+        "    llm = LLM(path, api_base=api_base, api_key=api_key) if api_base else LLM(path)\n",
         "\n",
         "    # OR: print(llm(LLM_PROMPT_INPUT, defaultrole=\"user\"))\n",
         "    print(llm([{\"role\": \"user\", \"content\": prompt}]))\n",
@@ -751,11 +775,13 @@
         "for LLM_MODEL, LLM_CONFIG in LLM_MODELS.items():\n",
         "  LLM_MODEL_NAME = LLM_CONFIG['LLM_MODEL_NAME'] if 'LLM_MODEL_NAME' in LLM_CONFIG else None\n",
         "  TEXT_EMBEDDING_PATH = LLM_CONFIG['TEXT_EMBEDDING_PATH'] if 'TEXT_EMBEDDING_PATH' in LLM_CONFIG else None\n",
+        "  API_BASE = LLM_CONFIG['API_BASE'] if 'API_BASE' in LLM_CONFIG else None\n",
+        "  API_KEY = os.environ.get(LLM_CONFIG['ENV_VAR'][0]) if API_BASE and 'ENV_VAR' in LLM_CONFIG else None\n",
         "  print(\"-\" * 50)\n",
         "  print(LLM_MODEL)\n",
         "\n",
         "  # https://neuml.github.io/txtai/pipeline/text/llm/\n",
-        "  runllm(prompt=LLM_PROMPT_INPUT, path=LLM_MODEL_NAME)\n",
+        "  runllm(prompt=LLM_PROMPT_INPUT, path=LLM_MODEL_NAME, api_base=API_BASE, api_key=API_KEY)\n",
         "\n",
         "  # https://neuml.github.io/txtai/embeddings/\n",
         "  runembeddings(data=EMBEDDING_DATA, path=TEXT_EMBEDDING_PATH)\n",


### PR DESCRIPTION
## Summary

Adds a named [OrcaRouter](https://www.orcarouter.ai) entry to the "Getting started with LLM APIs" example notebook. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Gemini and more behind a single endpoint and API key. It also provides gateway-level security controls for AI agents.

I'm an engineer on the OrcaRouter team.

## What this changes

- `examples/70_Getting_started_with_LLM_APIs.ipynb`: adds an `ORCAROUTER` entry to `LLM_MODEL_CONFIG` (base URL `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`, default model `openai/openai/gpt-4o-mini`), a short "OrcaRouter" explainer cell, and threads `api_base`/`api_key` through the notebook's `runllm` helper so the entry runs end to end. Existing providers are unaffected - `api_base` is only forwarded when set.

## Why a named entry rather than the OpenAI-compatible escape hatch

txtai's LiteLLM backend already accepts any OpenAI-compatible endpoint through `api_base`. A named config entry makes [OrcaRouter](https://www.orcarouter.ai) directly discoverable and selectable in the notebook's provider table, alongside Gemini, OpenAI, Claude, Groq and the rest. Named routers such as `openai/orcarouter/auto` pick an upstream model per request, so the same entry can serve the whole model catalog from one key.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. In the notebook, set `IS_ENABLED: True` for `ORCAROUTER` and run; the LLM pipeline routes `openai/gpt-4o-mini` through OrcaRouter. `openai/orcarouter/auto` auto-routes to the best available model per request.

## Verification

- Notebook JSON parses and all code cells compile.
- Live API: ran the notebook's exact `runllm` flow with a real `ORCAROUTER_API_KEY` against `https://api.orcarouter.ai/v1`; `openai/openai/gpt-4o-mini` returned a completion (HTTP 200). Also verified the auto-routing alias `openai/orcarouter/auto` responds.
