### PR TITLE
Read pooling_mode_mean_tokens with get() so a partial config does not raise

### DIFF
--- a/src/python/txtai/models/pooling/factory.py
+++ b/src/python/txtai/models/pooling/factory.py
@@ -81,11 +81,11 @@ class PoolingFactory:
         config = PoolingFactory.load(path, "1_Pooling/config.json")
 
         # Set to CLS pooling if it's enabled and mean pooling is disabled
-        if config and config.get("pooling_mode_cls_token") and not config["pooling_mode_mean_tokens"]:
+        if config and config.get("pooling_mode_cls_token") and not config.get("pooling_mode_mean_tokens"):
             method = "clspooling"
 
         # Set to last token pooling if it's enabled and mean pooling is disabled
-        if config and config.get("pooling_mode_lasttoken") and not config["pooling_mode_mean_tokens"]:
+        if config and config.get("pooling_mode_lasttoken") and not config.get("pooling_mode_mean_tokens"):
             method = "lastpooling"
 
         # Check for late interaction pooling

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -5,6 +5,7 @@ Pooling module tests
 import os
 import tempfile
 import unittest
+import unittest.mock
 
 import numpy as np
 import torch
@@ -442,6 +443,25 @@ class TestPooling(unittest.TestCase):
 
         # Encoding must be deterministic for a fixed seed
         self.assertTrue(np.allclose(outputs, muvera(data, "data"), atol=1e-5))
+
+    def testPartialPoolingConfig(self):
+        """
+        Test pooling config files that omit pooling_mode_mean_tokens
+        """
+
+        # A missing mean flag reads as disabled, same as an explicit false, instead of raising KeyError
+        tests = [
+            ({"pooling_mode_cls_token": True}, "clspooling"),
+            ({"pooling_mode_cls_token": True, "pooling_mode_mean_tokens": False}, "clspooling"),
+            ({"pooling_mode_lasttoken": True}, "lastpooling"),
+            ({"pooling_mode_lasttoken": True, "pooling_mode_mean_tokens": False}, "lastpooling"),
+            ({"pooling_mode_cls_token": True, "pooling_mode_mean_tokens": True}, "meanpooling"),
+            ({}, "meanpooling"),
+        ]
+
+        for config, expected in tests:
+            with unittest.mock.patch.object(PoolingFactory, "load", return_value=config):
+                self.assertEqual(PoolingFactory.method("sentence-transformers/nli-mpnet-base-v2"), expected)
 
     def testPrompts(self):
         """


### PR DESCRIPTION
Closes #1187

`PoolingFactory.method()` guarded every other pooling flag with `.get()` but read `pooling_mode_mean_tokens` with a bracket lookup, so a `1_Pooling/config.json` that sets a mode without that key raised `KeyError` out of `PoolingFactory.create()` instead of resolving a method:

```python
with patch.object(PoolingFactory, "load", return_value={"pooling_mode_cls_token": True}):
    PoolingFactory.method("any/model")   # KeyError: 'pooling_mode_mean_tokens'
```

A missing flag now reads as disabled, matching an explicit `false` and the defensive style used by the rest of the module (`config and config.get(...)`, `maxlength()`'s `if config` guard, `load()` swallowing `DownloadError`).

### Tests

`testPartialPoolingConfig` covers the resolution table both ways — cls/last with the mean key absent and present-and-false both resolve to their method, mean-enabled and an empty config resolve to `meanpooling`.

### Note on #1186

#1186 adds a third flag check on the same lines (`pooling_mode_max_tokens`). Whichever of the two lands second I'll bring in line — it's a one-token change either way.