### PR TITLE
Fix KeyError resolving a pooling method from a partial config

### DIFF
--- a/src/python/txtai/models/pooling/factory.py
+++ b/src/python/txtai/models/pooling/factory.py
@@ -81,11 +81,11 @@ class PoolingFactory:
         config = PoolingFactory.load(path, "1_Pooling/config.json")
 
         # Set to CLS pooling if it's enabled and mean pooling is disabled
-        if config and config.get("pooling_mode_cls_token") and not config["pooling_mode_mean_tokens"]:
+        if config and config.get("pooling_mode_cls_token") and not config.get("pooling_mode_mean_tokens"):
             method = "clspooling"
 
         # Set to last token pooling if it's enabled and mean pooling is disabled
-        if config and config.get("pooling_mode_lasttoken") and not config["pooling_mode_mean_tokens"]:
+        if config and config.get("pooling_mode_lasttoken") and not config.get("pooling_mode_mean_tokens"):
             method = "lastpooling"
 
         # Check for late interaction pooling

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -6,6 +6,8 @@ import os
 import tempfile
 import unittest
 
+from unittest.mock import patch
+
 import numpy as np
 import torch
 
@@ -45,6 +47,22 @@ class TestPooling(unittest.TestCase):
 
         # Test CLS pooling encoding
         self.assertEqual(pooling.encode(["test"])[0].shape, (768,))
+
+    def testMethodPartialConfig(self):
+        """
+        Test resolving a pooling method from a config that omits pooling_mode_mean_tokens
+        """
+
+        # Each flag on its own must resolve, rather than raising on the missing mean tokens key
+        with patch.object(PoolingFactory, "load", return_value={"pooling_mode_cls_token": True}):
+            self.assertEqual(PoolingFactory.method("any/model"), "clspooling")
+
+        with patch.object(PoolingFactory, "load", return_value={"pooling_mode_lasttoken": True}):
+            self.assertEqual(PoolingFactory.method("any/model"), "lastpooling")
+
+        # Mean pooling still wins when it is explicitly enabled
+        with patch.object(PoolingFactory, "load", return_value={"pooling_mode_cls_token": True, "pooling_mode_mean_tokens": True}):
+            self.assertEqual(PoolingFactory.method("any/model"), "meanpooling")
 
     def testLast(self):
         """


### PR DESCRIPTION
---

Fixes #1187

`PoolingFactory.method()` reads `pooling_mode_mean_tokens` with a bracket lookup while every other flag on the same two lines uses `.get()`:

```python
if config and config.get("pooling_mode_cls_token") and not config["pooling_mode_mean_tokens"]:
if config and config.get("pooling_mode_lasttoken") and not config["pooling_mode_mean_tokens"]:
```

A `1_Pooling/config.json` that sets a pooling mode but omits `pooling_mode_mean_tokens` therefore raises `KeyError` out of `PoolingFactory.create()` instead of resolving a method:

```python
with patch.object(PoolingFactory, "load", return_value={"pooling_mode_cls_token": True}):
    PoolingFactory.method("any/model")
# KeyError: 'pooling_mode_mean_tokens'
```

Same for `{"pooling_mode_lasttoken": True}`.

### Change

Both lookups use `.get()`, matching the flag right next to them. A missing key now reads as "mean pooling is not enabled", which is the same thing the surrounding code already assumes elsewhere — `maxlength()` guards with `if config`, and `load()` swallows `DownloadError` so an absent file returns `None`.

### Tests

`testMethodPartialConfig` covers a config with only `pooling_mode_cls_token`, one with only `pooling_mode_lasttoken`, and a control where `pooling_mode_mean_tokens` is explicitly enabled alongside the CLS flag so mean pooling still wins. It fails on `master` with the `KeyError` and passes with this change.

`black --line-length 150 --check` and `pylint --rcfile=.pylintrc` (10.00/10) are clean on the changed files. The full `test/python/testmodels/testpooling.py` suite passes: 18 passed, 13 subtests.
