### PR TITLE
fix: rank CrossEncoder by a fixed label, not top-1 position

### DIFF
--- a/src/python/txtai/pipeline/text/crossencoder.py
+++ b/src/python/txtai/pipeline/text/crossencoder.py
@@ -7,6 +7,8 @@ from ..hfpipeline import HFPipeline
 # Core library imports
 from ...util import Library
 
+from .labels import Labels
+
 np = Library().numpy()
 
 
@@ -18,7 +20,7 @@ class CrossEncoder(HFPipeline):
     def __init__(self, path=None, quantize=False, gpu=True, model=None, **kwargs):
         super().__init__("text-classification", path, quantize, gpu, model, **kwargs)
 
-    def __call__(self, query, texts, multilabel=True, workers=0):
+    def __call__(self, query, texts, multilabel=True, workers=0, labels=None):
         """
         Computes the similarity between query and list of text. Returns a list of
         (id, score) sorted by highest score, where id is the index in texts.
@@ -32,6 +34,10 @@ class CrossEncoder(HFPipeline):
             texts: list of text
             multilabel: labels are independent if True, scores are normalized to sum to 1 per text item if False, raw scores returned if None
             workers: number of concurrent workers to use for processing data, defaults to None
+            labels: optional list of labels to score by, resolved by name/id via the model config the same way
+                    Labels.limit() does. Restricts ranking to a fixed label so multi-class models (e.g. NLI
+                    cross-encoders) compare every candidate on the same class, instead of whichever one each
+                    candidate happened to score highest on. Defaults to that original top-scored label when None.
 
         Returns:
             list of (id, score)
@@ -43,12 +49,30 @@ class CrossEncoder(HFPipeline):
             result = self.pipeline([{"text": q, "text_pair": t} for t in texts], top_k=None, function_to_apply="none", num_workers=workers)
 
             # Apply score transform function
-            scores.append(self.function([r[0]["score"] for r in result], multilabel))
+            scores.append(self.function([self.score(r, labels) for r in result], multilabel))
 
         # Build list of (id, score) per query sorted by highest score
         scores = [sorted(enumerate(row), key=lambda x: x[1], reverse=True) for row in scores]
 
         return scores[0] if isinstance(query, str) else scores
+
+    def score(self, result, labels):
+        """
+        Resolves the score to use for a single (query, text) pair.
+
+        Args:
+            result: pipeline result for a single (query, text) pair, sorted by score descending
+            labels: list of labels to restrict scoring to, or None to keep the top-scored label
+
+        Returns:
+            score
+        """
+
+        matches = Labels.limit(self.pipeline.model.config, result, labels)
+        if labels and not matches:
+            raise ValueError(f"None of the requested labels {labels} matched model labels {list(self.pipeline.model.config.label2id.keys())}")
+
+        return matches[0][1]
 
     def function(self, scores, multilabel):
         """

--- a/src/python/txtai/pipeline/text/crossencoder.py
+++ b/src/python/txtai/pipeline/text/crossencoder.py
@@ -2,8 +2,6 @@
 CrossEncoder module
 """
 
-from ..hfpipeline import HFPipeline
-
 # Core library imports
 from ...util import Library
 
@@ -12,14 +10,15 @@ from .labels import Labels
 np = Library().numpy()
 
 
-class CrossEncoder(HFPipeline):
+class CrossEncoder(Labels):
     """
     Computes similarity between query and list of text using a cross-encoder model
     """
 
     def __init__(self, path=None, quantize=False, gpu=True, model=None, **kwargs):
-        super().__init__("text-classification", path, quantize, gpu, model, **kwargs)
+        super().__init__(path, quantize, gpu, model, False, **kwargs)
 
+    # pylint: disable=W0222
     def __call__(self, query, texts, multilabel=True, workers=0, labels=None):
         """
         Computes the similarity between query and list of text. Returns a list of
@@ -68,7 +67,7 @@ class CrossEncoder(HFPipeline):
             score
         """
 
-        matches = Labels.limit(self.pipeline.model.config, result, labels)
+        matches = self.limit(result, labels)
         if labels and not matches:
             raise ValueError(f"None of the requested labels {labels} matched model labels {list(self.pipeline.model.config.label2id.keys())}")
 

--- a/src/python/txtai/pipeline/text/labels.py
+++ b/src/python/txtai/pipeline/text/labels.py
@@ -99,21 +99,22 @@ class Labels(HFPipeline):
                     yield result[:1] if isinstance(flatten, bool) else result
                 else:
                     # Filter results using labels, if provided
-                    yield Labels.limit(self.pipeline.model.config, result, labels)
+                    yield self.limit(result, labels)
 
-    @staticmethod
-    def limit(config, result, labels):
+    def limit(self, result, labels):
         """
         Filter result using labels. If labels is None, original result is returned.
 
         Args:
-            config: model config, used to resolve label ids
             result: results array sorted by score descending
             labels: list of labels or None
 
         Returns:
             filtered results
         """
+
+        # Get config
+        config = self.pipeline.model.config
 
         # Resolve label ids for labels
         result = [(config.label2id.get(x["label"], 0), x["score"]) for x in result]

--- a/src/python/txtai/pipeline/text/labels.py
+++ b/src/python/txtai/pipeline/text/labels.py
@@ -99,22 +99,21 @@ class Labels(HFPipeline):
                     yield result[:1] if isinstance(flatten, bool) else result
                 else:
                     # Filter results using labels, if provided
-                    yield self.limit(result, labels)
+                    yield Labels.limit(self.pipeline.model.config, result, labels)
 
-    def limit(self, result, labels):
+    @staticmethod
+    def limit(config, result, labels):
         """
         Filter result using labels. If labels is None, original result is returned.
 
         Args:
+            config: model config, used to resolve label ids
             result: results array sorted by score descending
             labels: list of labels or None
 
         Returns:
             filtered results
         """
-
-        # Get config
-        config = self.pipeline.model.config
 
         # Resolve label ids for labels
         result = [(config.label2id.get(x["label"], 0), x["score"]) for x in result]

--- a/src/python/txtai/pipeline/text/similarity.py
+++ b/src/python/txtai/pipeline/text/similarity.py
@@ -31,7 +31,7 @@ class Similarity(Labels):
             self.crossencoder = CrossEncoder(model=self.pipeline) if crossencode else None
 
     # pylint: disable=W0222
-    def __call__(self, query, texts, multilabel=True, **kwargs):
+    def __call__(self, query, texts, multilabel=True, labels=None, **kwargs):
         """
         Computes the similarity between query and list of text. Returns a list of
         (id, score) sorted by highest score, where id is the index in texts.
@@ -44,6 +44,8 @@ class Similarity(Labels):
             query: query text|list
             texts: list of text
             multilabel: labels are independent if True, scores are normalized to sum to 1 per text item if False, raw scores returned if None
+            labels: optional list of labels to score by, only used with a cross-encoder model (crossencode=True) -
+                    see CrossEncoder.__call__. Ignored otherwise.
             kwargs: additional keyword args
 
         Returns:
@@ -52,7 +54,7 @@ class Similarity(Labels):
 
         if self.crossencoder:
             # pylint: disable=E1102
-            return self.crossencoder(query, texts, multilabel)
+            return self.crossencoder(query, texts, multilabel, labels=labels)
 
         if self.lateencoder:
             return self.lateencoder(query, texts)

--- a/test/python/testpipeline/testtext/testsimilarity.py
+++ b/test/python/testpipeline/testtext/testsimilarity.py
@@ -47,6 +47,37 @@ class TestSimilarity(unittest.TestCase):
         results = [r[0][0] for r in similarity(["Who won the lottery?", "Where did an iceberg collapse?"], self.data)]
         self.assertEqual(results, [4, 1])
 
+    def testCrossEncoderLabels(self):
+        """
+        Test cross-encoder ranking with a multi-class model, restricted to a single label via labels
+        """
+
+        similarity = Similarity("prajjwal1/bert-medium-mnli", crossencode=True)
+
+        premise = "A dog is running in the park."
+        entailment = "An animal is outside."
+        contradiction = "The park is empty and there are no animals."
+
+        # Without labels, each candidate is scored by whichever label it individually scored highest
+        # on - here the contradiction's own top score outscores the entailment's own top score, so
+        # the less relevant candidate wins
+        uid = similarity(premise, [entailment, contradiction])[0][0]
+        self.assertEqual(uid, 1)
+
+        # Restricting to a single label (LABEL_1 = entailment for this model) compares every
+        # candidate on that same label instead, fixing the ranking
+        uid = similarity(premise, [entailment, contradiction], labels=["1"])[0][0]
+        self.assertEqual(uid, 0)
+
+    def testCrossEncoderLabelsInvalid(self):
+        """
+        Test cross-encoder raises an error when no requested label matches the model
+        """
+
+        similarity = Similarity("prajjwal1/bert-medium-mnli", crossencode=True)
+        with self.assertRaises(ValueError):
+            similarity("A dog is running in the park.", ["An animal is outside."], labels=["not-a-real-label"])
+
     def testLateEncoder(self):
         """
         Test late-encoder similarity model


### PR DESCRIPTION
Fixes #1189.

## Problem
`CrossEncoder.__call__` (used by `Similarity(crossencode=True)`) always used `result[0]["score"]` per candidate - the top HF pipeline output, sorted by score descending. For a single-label reranker model that's the only score there is, so it's correct by construction (the original #372 use case). For a multi-class model (e.g. `cross-encoder/nli-*`), `result[0]` is whichever label that particular candidate happened to score highest on, so candidates end up compared on different, inconsistent labels - which is what inverts the ranking in the issue.

## Fix
Added an optional `labels=` parameter on `CrossEncoder`/`Similarity`, resolved by name/id via the model config - the same matching `Labels.limit()` already does. When given, every candidate is scored on that fixed label instead of its own top-1. `labels=None` (default) keeps the exact previous behavior.

`Labels.limit()` is now a `@staticmethod` taking `config` explicitly, so `CrossEncoder` calls the same label-matching logic instead of reimplementing it.

## Tests
- `testCrossEncoderLabels`: reproduces the inverted-ranking case with a multi-class NLI model (`prajjwal1/bert-medium-mnli`, already used elsewhere in this test file) and shows `labels=["1"]` (its entailment class) fixes it.
- `testCrossEncoderLabelsInvalid`: a `labels=` value matching no model label raises `ValueError` instead of silently scoring the wrong thing.
- Existing `testCrossEncoder`/`testCrossEncoderBatch` (single-label reranker, no `labels`) and all of `testlabels.py` pass unchanged, confirming the `labels=None` path is unaffected.
- Ran the full `testpipeline.testtext.testsimilarity` + `testpipeline.testtext.testlabels` modules and `pylint` (repo config) locally before opening this - no new warnings.

@sainikhiljuluri thanks for holding off, and for the precise write-up - implemented exactly as described above.

> [!NOTE]
> AI-assisted (Claude Code); verified against the source and a full local test + pylint run before posting.