### PR TITLE
Resolve LEMUR and MUVERA settings

### DIFF
--- a/docs/embeddings/configuration/vectors.md
+++ b/docs/embeddings/configuration/vectors.md
@@ -176,6 +176,7 @@ muvera:
 ```
 
 Settings to control the size of MUVERA fixed dimensional outputs. Default is 20 * 2^5 * 16 = 10,240 dimensions.
+Set `muvera` to `false` to disable it or `true` to use the default settings.
 
 ### lemur
 ```yaml
@@ -184,9 +185,9 @@ lemur:
 ```
 
 Loads a trained [LEMUR](../../../pipeline/train/lemur) fixed dimensional encoder. LEMUR artifacts are corpus-specific and must be
-created with `LemurTrainer` before configuring an embeddings index. Query vectors are summed learned features and document vectors
-are ordinary least squares weights over the artifact's stored token sample. Each artifact contains `config.json` and
-`model.safetensors`; newly trained artifacts also store the collection token mean as `lemur.center`. Loading that mean automatically
+created with `LemurTrainer` before configuring an embeddings index. A bare string is treated as the artifact path. Query vectors are
+summed learned features and document vectors are ordinary least squares weights over the artifact's stored token sample. Each artifact
+contains `config.json` and `model.safetensors`; newly trained artifacts also store the collection token mean as `lemur.center`. Loading that mean automatically
 selects collection centering unless `center` is explicitly configured. Artifacts without `lemur.center` retain the previous default.
 The Safetensors file contains inference state only. See the trainer page for score filtering and Faiss exact/IVF search behavior.
 

--- a/src/python/txtai/models/pooling/late.py
+++ b/src/python/txtai/models/pooling/late.py
@@ -24,8 +24,8 @@ class LatePooling(Pooling):
     def __init__(self, path, device, tokenizer=None, maxlength=None, loadprompts=None, modelargs=None):
         # Check if fixed dimensional encoder is enabled
         modelargs = modelargs.copy() if modelargs else {}
-        muvera = modelargs.pop("muvera", {})
-        lemur = modelargs.pop("lemur", None)
+        muvera = self.encodersettings(modelargs.pop("muvera", {}), "muvera")
+        lemur = self.encodersettings(modelargs.pop("lemur", None), "lemur")
         centerconfigured = "center" in modelargs
         center = modelargs.pop("center", None)
 
@@ -147,6 +147,34 @@ class LatePooling(Pooling):
 
         # Build NumPy array
         return np.asarray(padded)
+
+    @staticmethod
+    def encodersettings(settings, name):
+        """
+        Validates and resolves fixed encoder settings.
+
+        Args:
+            settings: fixed encoder configuration
+            name: fixed encoder name
+
+        Returns:
+            resolved fixed encoder configuration
+        """
+
+        if settings is None or settings is False:
+            return None
+
+        if isinstance(settings, dict):
+            return settings
+
+        if name == "lemur" and isinstance(settings, str):
+            return {"path": settings}
+
+        if name == "muvera" and settings is True:
+            return {}
+
+        expected = "a path string or a dict of settings" if name == "lemur" else "a boolean or a dict of settings"
+        raise ValueError(f"{name} expects {expected}")
 
     def centersettings(self, center, linear, configured):
         """

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -83,6 +83,35 @@ class TestPooling(unittest.TestCase):
         self.assertEqual(pool.centersettings({"scope": "batch"}, empty, True), {"scope": "batch"})
         self.assertEqual(pool.centersettings({"scope": "document"}, empty, True), {"scope": "document"})
 
+    def testLateEncoderSettings(self):
+        """
+        Test late pooling fixed encoder settings
+        """
+
+        pool = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device, "modelargs": {"muvera": None}})
+        lemur = {"path": "artifact"}
+        muvera = {"repetitions": 5}
+
+        self.assertIsNone(pool.encodersettings(None, "lemur"))
+        self.assertIsNone(pool.encodersettings(False, "lemur"))
+        self.assertEqual(pool.encodersettings("artifact", "lemur"), {"path": "artifact"})
+        self.assertIs(pool.encodersettings(lemur, "lemur"), lemur)
+
+        self.assertIsNone(pool.encodersettings(None, "muvera"))
+        self.assertIsNone(pool.encodersettings(False, "muvera"))
+        self.assertEqual(pool.encodersettings(True, "muvera"), {})
+        self.assertIs(pool.encodersettings(muvera, "muvera"), muvera)
+
+        for value in (True, 1):
+            with self.subTest(lemur=value):
+                with self.assertRaisesRegex(ValueError, "^lemur expects a path string or a dict of settings$"):
+                    pool.encodersettings(value, "lemur")
+
+        for value in ("settings", 1):
+            with self.subTest(muvera=value):
+                with self.assertRaisesRegex(ValueError, "^muvera expects a boolean or a dict of settings$"):
+                    pool.encodersettings(value, "muvera")
+
     def testLateCenterDisabled(self):
         """
         Test omitted and explicitly disabled centering are byte-identical
@@ -237,6 +266,10 @@ class TestPooling(unittest.TestCase):
                 self.assertTrue(np.isfinite(queries).all())
                 self.assertTrue(np.isfinite(documents).all())
 
+                pathpooling = PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"lemur": output, "center": False}})
+                self.assertIsInstance(pathpooling.encoder, Lemur)
+                np.testing.assert_allclose(pathpooling.encode(texts, category="data"), documents, rtol=1e-4, atol=1e-5)
+
                 # LEMUR must use true token counts, independent of batch padding
                 singles = np.vstack([pooling.encode([text], category="data") for text in texts])
                 np.testing.assert_allclose(documents, singles, rtol=1e-4, atol=1e-5)
@@ -244,6 +277,9 @@ class TestPooling(unittest.TestCase):
             # MUVERA remains the default when LEMUR is absent
             pooling = PoolingFactory.create({"path": model, "device": self.device})
             self.assertEqual(pooling.encode(["test"], category="query").shape, (1, 10240))
+
+            pooling = PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"muvera": False}})
+            self.assertIsNone(pooling.encoder)
 
     def testLemurActivations(self):
         """


### PR DESCRIPTION
`lemur` and `muvera` values that aren't dictionaries reach the constructor splats in `LatePooling` and raise a raw `TypeError`, so `muvera: false` fails instead of disabling MUVERA. This resolves `None` and `false` as disabled for either encoder, a bare `lemur` string as the artifact path, and `muvera: true` as the constructor defaults, while anything else raises a `ValueError` naming the key and the accepted forms. Documented dictionary forms construct exactly what they did, and `lemur` still takes precedence when both are set. I added tests for each form and ran the full `testpooling` module with 22 passing, plus pylint and black.