### PR TITLE
Fix WordVectors.index() silently dropping the checkpoint argument

### DIFF
--- a/src/python/txtai/vectors/dense/words.py
+++ b/src/python/txtai/vectors/dense/words.py
@@ -5,7 +5,6 @@ Word Vectors module
 import json
 import logging
 import os
-import tempfile
 
 from multiprocessing import Pool
 
@@ -21,6 +20,7 @@ from ...pipeline import Tokenizer
 from ...util import Download, DownloadError, Library
 
 from ..base import Vectors
+from ..recovery import Recovery
 
 # Core library imports
 np = Library().numpy()
@@ -158,7 +158,7 @@ class WordVectors(Vectors):
 
         # Use default single process indexing logic
         if not parallel:
-            return super().index(documents, batchsize)
+            return super().index(documents, batchsize, checkpoint)
 
         # Customize indexing logic with multiprocessing pool to efficiently build vectors
         ids, dimensions, batches, stream = [], None, 0, None
@@ -166,31 +166,59 @@ class WordVectors(Vectors):
         # Shared objects with Pool
         args = (self.config, self.scoring)
 
+        # Generate recovery config if checkpoint is set
+        vectorsid = self.vectorsid() if checkpoint else None
+        recovery = Recovery(checkpoint, vectorsid, self.loadembeddings) if checkpoint else None
+
         # Convert all documents to embedding arrays, stream embeddings to disk to control memory usage
         with Pool(parallel, initializer=create, initargs=args) as pool:
-            with tempfile.NamedTemporaryFile(mode="wb", suffix=".npy", delete=False) as output:
+            with self.spool(checkpoint, vectorsid) as output:
                 stream = output.name
-                embeddings = []
-                for uid, embedding in pool.imap(transform, documents, self.encodebatch):
-                    if not dimensions:
-                        # Set number of dimensions for embeddings
-                        dimensions = embedding.shape[0]
+                batch = []
+                for document in documents:
+                    batch.append(document)
 
-                    ids.append(uid)
-                    embeddings.append(embedding)
-
-                    if len(embeddings) == batchsize:
-                        np.save(output, np.array(embeddings, dtype=np.float32), allow_pickle=False)
+                    if len(batch) == batchsize:
+                        uids, dimensions = self.parallelbatch(pool, batch, output, recovery)
+                        ids.extend(uids)
                         batches += 1
 
-                        embeddings = []
+                        batch = []
 
-                # Final embeddings batch
-                if embeddings:
-                    np.save(output, np.array(embeddings, dtype=np.float32), allow_pickle=False)
+                # Final batch
+                if batch:
+                    uids, dimensions = self.parallelbatch(pool, batch, output, recovery)
+                    ids.extend(uids)
                     batches += 1
 
         return (ids, dimensions, batches, stream)
+
+    def parallelbatch(self, pool, documents, output, recovery):
+        """
+        Builds a batch of embeddings using the multiprocessing pool, honoring a recovery
+        checkpoint if one is available for this batch.
+
+        Args:
+            documents: list of documents used to build embeddings
+            pool: multiprocessing pool used to transform documents not served from recovery
+            output: output stream to store embeddings
+            recovery: optional recovery instance
+
+        Returns:
+            (ids, dimensions) list of ids and number of dimensions in embeddings
+        """
+
+        ids = [uid for uid, _, _ in documents]
+
+        # Attempt to read embeddings from a recovery file
+        embeddings = recovery() if recovery else None
+        if embeddings is None:
+            embeddings = np.array([embedding for _, embedding in pool.imap(transform, documents, self.encodebatch)], dtype=np.float32)
+
+        dimensions = embeddings.shape[1]
+        self.saveembeddings(output, embeddings)
+
+        return (ids, dimensions)
 
     def lookup(self, tokens):
         """

--- a/test/python/testvectors/testdense/testwordvectors.py
+++ b/test/python/testvectors/testdense/testwordvectors.py
@@ -3,6 +3,7 @@ WordVectors module tests
 """
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -122,6 +123,45 @@ class TestWordVectors(unittest.TestCase):
         with open(stream, "rb") as queue:
             self.assertEqual(np.load(queue).shape, (512, 300))
             self.assertEqual(np.load(queue).shape, (488, 300))
+
+    def testIndexCheckpoint(self):
+        """
+        Test word vector indexing writes a checkpoint file and a second run over the same
+        documents is served entirely from it
+        """
+
+        checkpoint = os.path.join(tempfile.gettempdir(), "wordvectors-checkpoint")
+        shutil.rmtree(checkpoint, ignore_errors=True)
+
+        documents = [(x, "This is a test", None) for x in range(10)]
+        model = VectorsFactory.create({"path": self.path, "parallel": False}, None)
+
+        # First run builds the checkpoint
+        model.index(documents, 5, checkpoint)
+        self.assertTrue(os.path.exists(os.path.join(checkpoint, model.vectorsid())))
+
+        # Second run over the same documents must be fully served from the checkpoint
+        with patch.object(WordVectors, "encode", wraps=model.encode) as encode:
+            model.index(documents, 5, checkpoint)
+            encode.assert_not_called()
+
+    @patch("os.cpu_count")
+    def testIndexCheckpointParallel(self, cpucount):
+        """
+        Test word vector parallel indexing writes a checkpoint file
+        """
+
+        # Mock CPU count
+        cpucount.return_value = 1
+
+        checkpoint = os.path.join(tempfile.gettempdir(), "wordvectors-checkpoint-parallel")
+        shutil.rmtree(checkpoint, ignore_errors=True)
+
+        documents = [(x, "This is a test", None) for x in range(10)]
+        model = VectorsFactory.create({"path": self.path, "parallel": True}, None)
+
+        model.index(documents, 5, checkpoint)
+        self.assertTrue(os.path.exists(os.path.join(checkpoint, model.vectorsid())))
 
     def testLookup(self):
         """


### PR DESCRIPTION
## Root cause

`WordVectors.index()` (`src/python/txtai/vectors/dense/words.py`) accepts a `checkpoint` argument but never uses it. The non-parallel branch calls `super().index(documents, batchsize)`, dropping `checkpoint` before it reaches `Vectors.index()`'s own `Recovery` wiring. The parallel (multiprocessing `Pool`) branch writes straight to a plain `tempfile.NamedTemporaryFile` and never touches `Recovery` at all. `WordVectors` is the only backend that overrides `index()`, so every other backend already gets checkpointing for free through `Vectors.index()`; this one silently drops it in both of its own code paths.

## Fix

- Non-parallel branch: pass `checkpoint` through to `super().index()`.
- Parallel branch: mirror `Vectors.index()`'s pattern. Generate a `Recovery` instance when `checkpoint` is set, write through `self.spool(checkpoint, vectorsid)` instead of a bare temp file, and batch documents so each batch can be served from `recovery()` before falling back to the pool. Extracted the per-batch logic into `parallelbatch()` since the outer loop needed to call it twice (mid-loop flush and final partial batch), same shape as the existing non-parallel `Vectors.batch()`.

## Tests

Added `testIndexCheckpoint` (serial) and `testIndexCheckpointParallel` (parallel) to `test/python/testvectors/testdense/testwordvectors.py`. Both fail on `main` and pass on this branch:

- `testIndexCheckpoint` asserts the checkpoint file exists after indexing, then re-indexes the same documents and asserts `encode` is never called again (fully served from the checkpoint).
- `testIndexCheckpointParallel` asserts the checkpoint file exists for the parallel path (the second assertion cannot cross the `multiprocessing.Pool` fork boundary reliably, so I checked it separately, see below).

## Verified

- New tests fail on `main` (`a10667a1`) and pass on this branch, in Docker.
- Kill-and-resume checked directly for both branches: interrupted an indexing run after 10 of 20 documents, then resumed with the same checkpoint directory over the full document list. On `main`, the second run re-embeds all 20. On this branch, it re-embeds only the 10 that were not yet checkpointed, for both `parallel: True` and `parallel: False`.
- `test/python/testvectors/testdense/testwordvectors.py` and `testvectors.py`: all pass, using the real `neuml/glove-6B-quantized` model.
- `black --check` and `pylint` (10.00/10, repo's own `.pylintrc`) plus `pre-commit run` (both hooks) on the changed files.
- Coverage on the changed package: every line touched by this diff is exercised by the test file above; did not run the full `make data coverage` matrix (needs the full `[all,dev]` extras and downloaded fixtures), scoped to the changed module and its tests.

Fixes #1197
