### PR TITLE
fix(ann): exclude deleted rows from quantized numpy search results

### DIFF
--- a/src/python/txtai/ann/dense/numpy.py
+++ b/src/python/txtai/ann/dense/numpy.py
@@ -70,6 +70,10 @@ class NumPy(ANN):
         if self.qbits:
             # Calculate hamming score for integer vectors
             scores = self.hammingscore(queries)
+
+            # Zero out deleted (all-zero) rows. Unlike dot product, hamming scores them nonzero,
+            # so they'd otherwise pass the caller's score > 0 filter and resurface in results.
+            scores[:, self.all(self.backend == 0, axis=1)] = 0
         else:
             # Dot product on normalized vectors is equal to cosine similarity
             scores = self.dot(self.tensor(queries), self.backend.T)

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -284,6 +284,25 @@ class TestDense(unittest.TestCase):
         # Validate count
         self.assertEqual(ann.count(), 100)
 
+    def testNumPyQuantizeDelete(self):
+        """
+        Test that deleted rows don't resurface in search results for quantized (hamming) NumPy indexes
+        """
+
+        ann = ANNFactory.create({"backend": "numpy", "quantize": 1, "dimensions": 4})
+
+        # Index uint8 vectors
+        data = np.array([[1, 0, 0, 0], [0, 255, 0, 0], [0, 0, 255, 0], [0, 0, 0, 255]], dtype=np.uint8)
+        ann.index(data)
+
+        # Delete the first row and search with its (former) vector
+        ann.delete([0])
+        results = ann.search(np.array([data[0]]), 4)[0]
+
+        # Deleted row must score 0 so the caller's score > 0 filter drops it, same as the dot-product path
+        self.assertEqual(dict(results).get(0), 0)
+        self.assertEqual(ann.count(), 3)
+
     @patch("sqlalchemy.orm.Query.limit")
     def testPGVector(self, query):
         """


### PR DESCRIPTION
Deletes in the numpy/torch ANN backends work by zeroing out the row, and the search layer relies on its `score > 0` filter to drop those rows afterwards. That holds for the default dot-product path — a zeroed row dot-products to exactly 0 — but not for the quantized (hamming) path. `hammingscore` scores a zeroed row as `1.0 - popcount(query)/nbits`, which is positive and, for a sparse query, often ends up near the top. So on a quantized index, deleting a document doesn't actually remove it: searching for its old vector returns it ranked first, and with `content=False` you get a phantom `(None, score)` hit ahead of real matches.

`count()` already treats all-zero rows as deleted; `search()` just wasn't applying the same rule on the hamming branch. Zeroing those columns out makes deleted rows score 0 so they fall out of the filter the same way they do for dot product. The fix lives in the shared `NumPy.search`, so the torch backend (which inherits it) is covered too.

Added a test that indexes a quantized numpy backend, deletes a row, and asserts its old vector no longer comes back with a nonzero score.
