### PR TITLE
fix(scoring): keep count() accurate when an id is deleted more than once

### DIFF
--- a/src/python/txtai/scoring/terms.py
+++ b/src/python/txtai/scoring/terms.py
@@ -129,8 +129,14 @@ class Terms:
             ids: ids to delete
         """
 
-        # Set index ids as deleted, ignore ids that were never indexed
-        self.deletes.extend([self.ids.index(i) for i in ids if i in self.ids])
+        # Set index ids as deleted, ignoring ids that were never indexed and ids
+        # already marked deleted. Skipping duplicates keeps count() accurate when
+        # the same id is deleted more than once (e.g. repeated upsert/delete flows).
+        for i in ids:
+            if i in self.ids:
+                indexid = self.ids.index(i)
+                if indexid not in self.deletes:
+                    self.deletes.append(indexid)
 
     def index(self):
         """

--- a/test/python/testscoring/testkeyword.py
+++ b/test/python/testscoring/testkeyword.py
@@ -166,6 +166,26 @@ class TestKeyword(unittest.TestCase):
         scoring.delete([0, len(self.data) + 100])
         self.assertNotIn(0, scoring.documents)
 
+    def testDeleteIdempotent(self):
+        """
+        Test that deleting the same id more than once does not corrupt count()
+        """
+
+        # Terms index (bm25): Terms.delete extended self.deletes without dedup, so a
+        # repeated delete appended the same index again and count() undercounted.
+        scoring = ScoringFactory.create({"method": "bm25", "terms": True, "content": True})
+        scoring.index(self.data)
+
+        total = scoring.count()
+        self.assertEqual(total, len(self.data))
+
+        scoring.delete([0])
+        self.assertEqual(scoring.count(), total - 1)
+
+        # Deleting the same id again is a no-op for the count
+        scoring.delete([0])
+        self.assertEqual(scoring.count(), total - 1)
+
     def testTFIDF(self):
         """
         Test tfidf


### PR DESCRIPTION
### Problem

`Terms.delete()` marks ids deleted by appending their positional index to `self.deletes`:

```python
self.deletes.extend([self.ids.index(i) for i in ids if i in self.ids])
```

It never checks whether an index is already marked. Since `count()` returns
`len(self.ids) - len(self.deletes)`, deleting the same id more than once appends a
duplicate index and makes `count()` **undercount**. Repeated `delete` of the same id
(a normal upsert / re-delete pattern), or a repeated id within one `delete([...])`
call, corrupts the reported size:

```python
s = ScoringFactory.create({"method": "bm25", "terms": True, "content": True})
s.index(data)          # 7 docs
s.count()              # 7
s.delete([0]); s.count()   # 6  ✓
s.delete([0]); s.count()   # 5  ✗  (should still be 6)
```

Enough repeats drive `count()` to zero or negative.

### Fix

Skip ids whose index is already in `self.deletes`, so a repeated delete is a no-op for
the count. `self.deletes` stays a `list` — it is consumed by numpy fancy indexing in
`score()` (`scores[self.deletes] = 0`) and by membership checks in `save()`
(`1 if i in self.deletes else 0`) — so only duplicate appends are removed; no other
behaviour changes. This also handles a repeated id inside a single `delete()` call,
which the old list-comprehension did not.

### Testing

Added `testDeleteIdempotent` in `test/python/testscoring/testkeyword.py`: it indexes the
fixture, deletes id `0` twice, and asserts `count()` is `total - 1` both times. It fails
on the previous code (second delete yields `total - 2`) and passes with the fix.

```
$ python -m unittest testscoring.testkeyword.TestKeyword.testDeleteIdempotent \
                      testscoring.testkeyword.TestKeyword.testDeleteUnknownId
Ran 2 tests ... OK
```

### Risk / back-compat

No API change; `delete()` behaviour is only corrected. `testDeleteUnknownId` (the
prior fix to this method) still passes.
