### PR TITLE
Fix safetensors numpy/torch submodule imports

### DIFF
--- a/src/python/txtai/util/library.py
+++ b/src/python/txtai/util/library.py
@@ -212,6 +212,10 @@ class Library:
         try:
             import safetensors
 
+            # Import submodules - they are not auto-imported with safetensors
+            import safetensors.numpy
+            import safetensors.torch
+
         except ImportError:
 
             class Safetensors:


### PR DESCRIPTION
---

Fixes #1204

## Root cause

`txtai/ann/dense/numpy.py` loads safetensors through the lazy helper `library.safetensors()`, which only executes `import safetensors`. Line 175 then calls `safetensors.numpy.save_file(...)`, but the `numpy` submodule attribute only exists if **some other package in the process imported `safetensors.numpy` first** — safetensors never auto-imports its `numpy`/`torch` submodules (checked `__init__.py` in 0.7.0 and 0.8.0).

This is a regression introduced in **9.9.0**:

* 9.8.0 and earlier: `from safetensors.numpy import save_file` (explicit import) — works
* 9.9.0: refactored to `library.safetensors()` + `safetensors.numpy.save_file` — broken

It is masked in CI because the build installs `.[all,dev]`, and `staticvectors` (in the `vectors` extra) happens to `import safetensors.numpy` at package import time.

## Change

`library.safetensors()` now explicitly imports the `safetensors.numpy` and `safetensors.torch` submodules. A single location covers every affected path:

* NumPy ANN backend (`numpy.py`)
* Torch ANN backend (inherits `savesafetensors` via `super()`)
* LEMUR pooling model save (`models/pooling/lemur.py`)

The existing `ImportError` fallback stub is unchanged, so installs without safetensors degrade the same way as before.

## Tests

* `test/python/testann/testdense.py::testNumPySafetensors` — fails on `master` with `AttributeError: module 'safetensors' has no attribute 'numpy'`, passes with this change
* Full `testdense.py` suite: no new failures (remaining errors are pre-existing optional-dependency skips)
* `black --line-length 150 --check` and `pylint --rcfile=.pylintrc` (10.00/10) clean on the changed file
* Verified the stub fallback path (safetensors not installed) still raises the expected `ImportError` on attribute access
