### PR TITLE
Index zero and False values in the tabular pipeline

### DIFF
--- a/src/python/txtai/pipeline/data/tabular.py
+++ b/src/python/txtai/pipeline/data/tabular.py
@@ -135,7 +135,7 @@ class Tabular(Pipeline):
         parts = []
         for column in columns:
             column = self.column(row[column])
-            if column:
+            if column is not None and column != "":
                 parts.append(str(column))
 
         return ". ".join(parts) if parts else None

--- a/test/python/testpipeline/testdata/testtabular.py
+++ b/test/python/testpipeline/testdata/testtabular.py
@@ -23,6 +23,36 @@ class TestTabular(unittest.TestCase):
 
         cls.tabular = Tabular("id", ["text"])
 
+    def testFalsyValues(self):
+        """
+        Test that zero and False are indexed as content
+        """
+
+        tabular = Tabular("id", ["quantity", "text"])
+
+        # A quantity of 0 is real data. Before this was fixed, the truthy check in concat
+        # dropped it and the row indexed as "Widget", losing the quantity.
+        rows = tabular([{"id": 1, "quantity": 0, "text": "Widget"}])
+        self.assertEqual(rows[0][1], "0. Widget")
+
+        rows = tabular([{"id": 2, "quantity": False, "text": "Widget"}])
+        self.assertEqual(rows[0][1], "False. Widget")
+
+    def testNullValues(self):
+        """
+        Test that null and empty values are still skipped
+        """
+
+        tabular = Tabular("id", ["quantity", "text"])
+
+        # NaN is the null marker column() normalizes to None, and an empty string adds
+        # nothing but a separator. Both stay excluded.
+        rows = tabular([{"id": 1, "quantity": float("nan"), "text": "Widget"}])
+        self.assertEqual(rows[0][1], "Widget")
+
+        rows = tabular([{"id": 2, "quantity": "", "text": "Widget"}])
+        self.assertEqual(rows[0][1], "Widget")
+
     def testContent(self):
         """
         Test parsing additional content


### PR DESCRIPTION
## Problem

`Tabular.concat()` builds the text that gets indexed for each row. It tested every column value for truthiness:

```python
column = self.column(row[column])
if column:
    parts.append(str(column))
```

`column()` normalizes NaN to `None` and returns everything else unchanged, so `None` is the marker for a missing value. The truthy test also drops `0`, `0.0` and `False`, which are real data.

A row of `{"id": 1, "quantity": 0, "text": "Widget"}` with `Tabular("id", ["quantity", "text"])` indexes as `"Widget"`. The quantity is gone, and nothing reports it.

Measured on current master:

| quantity | indexed text |
|---|---|
| `0` | `"Widget"` |
| `0.0` | `"Widget"` |
| `False` | `"Widget"` |
| `5` | `"5. Widget"` |

## Change

`concat()` now compares against the marker `column()` actually produces:

```python
if column is not None and column != "":
```

Empty strings stay excluded on purpose. Including them adds a `". "` separator and no content, so `{"quantity": "", "text": "Widget"}` would index as `". Widget"`.

After the change:

| quantity | indexed text |
|---|---|
| `0` | `"0. Widget"` |
| `0.0` | `"0.0. Widget"` |
| `False` | `"False. Widget"` |
| `""` | `"Widget"` |
| `NaN` | `"Widget"` |

## Tests

Two tests added to `test/python/testpipeline/testdata/testtabular.py`:

- `testFalsyValues` asserts `0` and `False` reach the indexed text
- `testNullValues` asserts NaN and empty strings are still skipped

Reverting the one-line change makes `testFalsyValues` fail while `testNullValues` still passes, so the new test covers the behaviour that changed and not the behaviour that did not.

`testtabular.py` reports 8 passed. `testCSV` fails in my environment because it wants `/tmp/txtai/tabular.csv`, and it fails the same way on an unmodified checkout.

`black --check` reports both files unchanged.
