### PR TITLE
Fix bash tool hanging on commands that read stdin

### DIFF
--- a/src/python/txtai/agent/tool/bash.py
+++ b/src/python/txtai/agent/tool/bash.py
@@ -6,6 +6,9 @@ import subprocess
 
 from smolagents import Tool
 
+# Default maximum time in seconds to wait for a command to complete
+TIMEOUT = 30
+
 
 class BashTool(Tool):
     """
@@ -14,12 +17,13 @@ class BashTool(Tool):
     """
 
     # pylint: disable=W0231
-    def __init__(self, allowed=None):
+    def __init__(self, allowed=None, timeout=None):
         """
         Creates a BashTool.
 
         Args:
             allowed: list of allowed commands to run, has limited set of defaults which are a best effort not a sandbox
+            timeout: maximum number of seconds to wait for a command to complete, defaults to 30
         """
 
         # Tool parameters
@@ -33,6 +37,9 @@ class BashTool(Tool):
         # Default list of allowed commands
         self.allowed = allowed if allowed else ["cat", "cut", "diff", "grep", "head", "ls", "tail"]
 
+        # Maximum time to wait for a command
+        self.timeout = timeout if timeout else TIMEOUT
+
         # Validate parameters and initialize tool
         super().__init__()
 
@@ -40,6 +47,9 @@ class BashTool(Tool):
     def forward(self, command):
         """
         Runs a shell command as a subprocess.
+
+        stdin is closed and a timeout is applied. Otherwise an allowed command called with no file arguments
+        (i.e. `cat`) reads from stdin and blocks the agent indefinitely.
 
         Args:
             command: command arguments as a list
@@ -50,6 +60,9 @@ class BashTool(Tool):
 
         output = None
         if command and command[0] in self.allowed:
-            output = subprocess.run(command, capture_output=True, text=True, check=False).stdout
+            try:
+                output = subprocess.run(command, capture_output=True, text=True, check=False, stdin=subprocess.DEVNULL, timeout=self.timeout).stdout
+            except subprocess.TimeoutExpired:
+                output = f"Command timed out after {self.timeout} seconds"
 
         return output

--- a/src/python/txtai/agent/tool/bash.py
+++ b/src/python/txtai/agent/tool/bash.py
@@ -6,9 +6,6 @@ import subprocess
 
 from smolagents import Tool
 
-# Default maximum time in seconds to wait for a command to complete
-TIMEOUT = 30
-
 
 class BashTool(Tool):
     """
@@ -17,13 +14,13 @@ class BashTool(Tool):
     """
 
     # pylint: disable=W0231
-    def __init__(self, allowed=None, timeout=None):
+    def __init__(self, allowed=None, timeout=30):
         """
         Creates a BashTool.
 
         Args:
             allowed: list of allowed commands to run, has limited set of defaults which are a best effort not a sandbox
-            timeout: maximum number of seconds to wait for a command to complete, defaults to 30
+            timeout: maximum number of seconds to wait for a command to complete, defaults to 30, None disables the timeout
         """
 
         # Tool parameters
@@ -37,8 +34,8 @@ class BashTool(Tool):
         # Default list of allowed commands
         self.allowed = allowed if allowed else ["cat", "cut", "diff", "grep", "head", "ls", "tail"]
 
-        # Maximum time to wait for a command
-        self.timeout = timeout if timeout else TIMEOUT
+        # Maximum time to wait for a command, None waits indefinitely
+        self.timeout = timeout
 
         # Validate parameters and initialize tool
         super().__init__()

--- a/test/python/testagent.py
+++ b/test/python/testagent.py
@@ -229,6 +229,9 @@ class TestAgent(unittest.TestCase):
 
         self.assertIn("timed out", tool(["sleep", "30"]))
 
+        # Timeout is disabled when set to None
+        self.assertIsNone(BashTool(timeout=None).timeout)
+
     def testToolsEmbeddings(self):
         """
         Test adding Embeddings as a tool

--- a/test/python/testagent.py
+++ b/test/python/testagent.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import unittest
 
+from threading import Thread
 from unittest.mock import patch
 
 from datetime import datetime
@@ -13,7 +14,7 @@ from datetime import datetime
 from smolagents import CodeAgent, PythonInterpreterTool
 
 from txtai.agent import Agent
-from txtai.agent.tool import ToolFactory
+from txtai.agent.tool import BashTool, ToolFactory
 from txtai.embeddings import Embeddings
 
 # agents.md content
@@ -188,6 +189,45 @@ class TestAgent(unittest.TestCase):
         tool = ToolFactory.default("bash")
         self.assertEqual(tool.name, "bash")
         self.assertIsNot(tool, ToolFactory.default("bash"))
+
+    def testToolsBashStdin(self):
+        """
+        Test default bash tool doesn't block reading stdin
+        """
+
+        tool = ToolFactory.default("bash")
+
+        # Replace stdin with a pipe that never reaches EOF, simulating a long-lived
+        # parent process (i.e. an API service) that keeps stdin open
+        read, write = os.pipe()
+        stdin = os.dup(0)
+
+        result = {}
+
+        try:
+            os.dup2(read, 0)
+
+            # `cat` with no file arguments reads stdin - run in a thread to avoid blocking the test suite
+            thread = Thread(target=lambda: result.update(output=tool(["cat"])), daemon=True)
+            thread.start()
+            thread.join(timeout=30)
+        finally:
+            os.dup2(stdin, 0)
+            for descriptor in (stdin, read, write):
+                os.close(descriptor)
+
+        # Command must return and not block forever reading stdin
+        self.assertFalse(thread.is_alive())
+        self.assertEqual(result["output"], "")
+
+    def testToolsBashTimeout(self):
+        """
+        Test bash tool commands are stopped once they exceed the timeout
+        """
+
+        tool = BashTool(allowed=["sleep"], timeout=1)
+
+        self.assertIn("timed out", tool(["sleep", "30"]))
 
     def testToolsEmbeddings(self):
         """


### PR DESCRIPTION
## Problem

`BashTool.forward` ran the command with no timeout and no stdin redirection:

```python
output = subprocess.run(command, capture_output=True, text=True, check=False).stdout
```

`capture_output=True` sets `stdout` and `stderr` to pipes but leaves `stdin` alone, so the child inherits the parent's stdin.

Every command in the default allowed list — `cat`, `cut`, `diff`, `grep`, `head`, `tail` — reads stdin when called with no file operand. So a model emitting `["cat"]`, or `["grep", "pattern"]` with the path omitted, blocks on a read that never returns. In a long-lived parent such as an API service or a notebook, stdin never reaches EOF, and because no `timeout` is passed there is nothing to break the wait: the agent is wedged permanently, holding the thread and the step budget.

Reproduced against `master` with the tool's real `forward()`:

```
REPRODUCED: BashTool.forward(['cat']) STILL BLOCKED after 10s
```

A model does not have to be adversarial to reach this — omitting a file argument is an ordinary generation slip, and the tool description invites `cat`.

## Fix

- Redirect stdin to `DEVNULL`, so a command that reads stdin sees EOF immediately and returns empty output instead of blocking.
- Add a `timeout` constructor argument, defaulting to 30 seconds, so a command that is slow for any other reason reports a timeout rather than hanging.

Both are needed. `DEVNULL` alone leaves any other long-running command unbounded, and a timeout alone would make every stdin-reading command wait the full timeout before failing.

The timeout returns a message rather than raising, so the agent can read what happened and adapt on its next step.

`ToolFactory.default("bash")` keeps working unchanged — both arguments are optional.

## Tests

`testToolsBashStdin` replaces stdin with a pipe that never reaches EOF, simulating a long-lived parent, then calls `["cat"]` on a thread and asserts it returns. On `master` it fails after blocking the full 30s join:

```
FAIL: testToolsBashStdin
AssertionError: True is not false
```

`testToolsBashTimeout` asserts a command exceeding the timeout reports one. On `master` it errors, as there is no `timeout` argument:

```
TypeError: BashTool.__init__() got an unexpected keyword argument 'timeout'
```

Both pass with the change.

- `python -m unittest -v testagent` — 11 tests, OK
- `black --check` clean, `pylint` 10.00/10

Closes #1209.
