### PR TITLE
fix(api): parse the graph query parameter as a bool

### DIFF
--- a/src/python/txtai/api/base.py
+++ b/src/python/txtai/api/base.py
@@ -32,7 +32,7 @@ class API(Application):
         weights = self.weights(request.query_params.get("weights") if request and hasattr(request, "query_params") else weights)
         index = request.query_params.get("index") if request and hasattr(request, "query_params") else index
         parameters = request.query_params.get("parameters") if request and hasattr(request, "query_params") else parameters
-        graph = request.query_params.get("graph") if request and hasattr(request, "query_params") else graph
+        graph = self.graph(request.query_params.get("graph") if request and hasattr(request, "query_params") else graph)
 
         # Decode parameters
         parameters = json.loads(parameters) if parameters and isinstance(parameters, str) else parameters
@@ -157,3 +157,17 @@ class API(Application):
         """
 
         return float(weights) if weights else weights
+
+    def graph(self, graph):
+        """
+        Parses the graph parameter from the request.
+
+        Args:
+            graph: graph parameter
+
+        Returns:
+            graph as a bool
+        """
+
+        # Query parameters are strings - accept the same values the batchsearch endpoint coerces
+        return graph.strip().lower() in ("1", "true", "yes", "on") if isinstance(graph, str) else bool(graph)

--- a/test/python/testapi/testapiembeddings.py
+++ b/test/python/testapi/testapiembeddings.py
@@ -109,6 +109,22 @@ embeddings:
     content: True
 """
 
+# Configuration for a graph index
+GRAPH = """
+# Index file path
+path: %s
+
+# Allow indexing of documents
+writable: True
+
+# Embeddings settings
+embeddings:
+    keyword: True
+    content: True
+    graph:
+        approximate: False
+"""
+
 # Configuration for reranker
 RERANK = """
 # Index file path
@@ -475,6 +491,27 @@ class TestEmbeddings(unittest.TestCase):
 
         uids = [result[0]["id"] for result in results]
         self.assertEqual(uids, ["3", "3"])
+
+    def testXSearchGraph(self):
+        """
+        Test the graph parameter via API
+        """
+
+        self.client = TestEmbeddings.start(GRAPH, "testapi-graph")
+
+        # Index data
+        self.client.post("add", json=[{"id": x, "text": row} for x, row in enumerate(self.data)])
+        self.client.get("index")
+
+        # Graph results are a serialized graph, standard results are a list
+        self.assertIsInstance(self.client.get("search?query=bear&limit=1&graph=true").json(), dict)
+
+        for value in ["false", "False", "0"]:
+            self.assertIsInstance(self.client.get(f"search?query=bear&limit=1&graph={value}").json(), list)
+
+        # Same query through batchsearch, which coerces the parameter with FastAPI
+        results = self.client.post("batchsearch", json={"queries": ["bear"], "limit": 1, "graph": False}).json()
+        self.assertIsInstance(results[0], list)
 
 
 class Elements:


### PR DESCRIPTION
`GET /search` takes `graph` straight off the query string and passes the raw value through, so any non-empty value turns graph mode on. `graph=false`, `graph=False` and `graph=0` all come back with a serialized graph instead of the usual result list. `POST /batchsearch` declares it as `graph: bool = Body(default=False)` and coerces it properly, so the two endpoints disagree on the same documented parameter.

Everything else in `API.search` is already parsed on the way in — `limit` goes through `self.limit()`, `weights` through `self.weights()`, `parameters` through `json.loads` — `graph` was the only one left raw. Added a `graph()` helper next to the others that accepts the same truthy values FastAPI does.

This also hits clusters quietly: `Cluster.search` appends `&graph={graph}` unconditionally, so with the default of `False` every shard request carried `graph=False` and a graph-enabled index ran in graph mode on every search.

The test starts a keyword + graph index through the API and checks that `graph=true` returns a graph while `false`, `False` and `0` return a list. It fails on main for those three.
