### PR TITLE
Load the Milvus collection when opening a saved index

### DIFF
--- a/src/python/txtai/ann/dense/milvus.py
+++ b/src/python/txtai/ann/dense/milvus.py
@@ -138,3 +138,6 @@ class Milvus(ANN):
 
         self.backend = milvus_lite.MilvusLite(self.path)
         self.collection = self.backend.get_collection("txtai")
+
+        # Reopened collections with an index start released, load to enable search
+        self.collection.load()

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -639,12 +639,20 @@ class TestDense(unittest.TestCase):
         # Generate temp file path
         index = os.path.join(tempfile.gettempdir(), "ann")
 
-        # Save and close index
-        model.save(index)
-        model.close()
+        # Generate query vector
+        query = np.random.rand(240).astype(np.float32)
+        self.normalize(query)
 
-        # Reload index
+        # Save index and ensure it's still searchable
+        model.save(index)
+        self.assertGreater(model.search(np.array([query]), 1)[0][0][1], 0)
+
+        # Close and reload index
+        model.close()
         model.load(index)
+
+        # Ensure reloaded index is searchable
+        self.assertGreater(model.search(np.array([query]), 1)[0][0][1], 0)
 
         return model
 


### PR DESCRIPTION
With `milvus-lite` 3.2.1, `search()` failed after `save()` or `load()` because an indexed collection reopened in the `released` state, while `count()` still worked. `open()` now calls `load()` on the reopened collection, and the idempotent collection load leaves fresh index behavior unchanged. I reproduced the released-collection failure, extended the shared save helper to search after save and reload, then ran `testann.testdense`, which completed 35 tests with 3 skipped and no failures, plus pre-commit.
