### PR TITLE
Ignore padding rows in LateEncoder scores

### DIFF
--- a/src/python/txtai/pipeline/text/lateencoder.py
+++ b/src/python/txtai/pipeline/text/lateencoder.py
@@ -95,8 +95,17 @@ class LateEncoder(Pipeline):
             list of (id, score)
         """
 
+        # Padding rows are all zeros, true token rows are unit normalized
+        qmask, dmask = queries.abs().sum(axis=-1) > 0, data.abs().sum(axis=-1) > 0
+
         # Compute bulk dot product using einstein notation
-        scores = torch.einsum("ash,bth->abst", queries, data).max(axis=-1).values.mean(axis=-1)
+        scores = torch.einsum("ash,bth->abst", queries, data)
+
+        # Max score per query token, ignoring padded data tokens
+        scores = scores.masked_fill(~dmask[None, :, None, :], torch.finfo(scores.dtype).min).max(axis=-1).values
+
+        # Mean score over true query tokens, ignoring padded query tokens
+        scores = scores.masked_fill(~qmask[:, None, :], 0).sum(axis=-1) / qmask.sum(axis=-1, keepdim=True).clamp(min=1)
         scores = scores.cpu().numpy()
 
         # Get top n matching indices and scores

--- a/test/python/testpipeline/testtext/testsimilarity.py
+++ b/test/python/testpipeline/testtext/testsimilarity.py
@@ -97,8 +97,36 @@ class TestSimilarity(unittest.TestCase):
         """
 
         similarity = Similarity("neuml/colbert-bert-tiny", lateencode=True)
-        results = [r[0][0] for r in similarity(["Who won the lottery?", "Where did an iceberg collapse?"], self.data)]
-        self.assertEqual(results, [4, 1])
+        queries = ["Who won the lottery?", "Where did an iceberg collapse?"]
+        results = similarity(queries, self.data)
+        self.assertEqual([r[0][0] for r in results], [4, 1])
+
+        # Test scores don't change with query batch padding
+        for query, scores in zip(queries, results):
+            alone = dict(similarity(query, self.data))
+            for uid, score in scores:
+                self.assertAlmostEqual(score, alone[uid], places=4)
+
+    def testLateEncoderPadding(self):
+        """
+        Test late-encoder scores don't change with data batch padding
+        """
+
+        texts = self.data + ["Short text."]
+        queries = ["Who won the lottery?", "Where did an iceberg collapse?"]
+
+        # Center token vectors on a fixed collection mean, this is batch independent and makes negative token similarities common
+        similarity = Similarity("neuml/colbert-bert-tiny", lateencode=True)
+        vectors = similarity.encode(texts, "data")
+        mean = vectors[vectors.abs().sum(dim=-1) > 0].mean(dim=0).cpu().numpy()
+        similarity = Similarity("neuml/colbert-bert-tiny", lateencode=True, vectors={"center": {"scope": "collection", "mean": mean}})
+
+        # Each text encoded alone has no padding, scores must match the exact MaxSim over true tokens
+        for query in queries:
+            scores, vectors = dict(similarity(query, texts)), similarity.encode([query], "query")[0]
+            for uid, text in enumerate(texts):
+                exact = (vectors @ similarity.encode([text], "data")[0].T).max(dim=1).values.mean().item()
+                self.assertAlmostEqual(scores[uid], exact, places=4)
 
     def testSimilarity(self):
         """


### PR DESCRIPTION
`LateEncoder` scores changed with the padded query length, and zero-padded document rows could win the per-token maximum under centering. This masks padded query and document rows before averaging, so single-query scores and rankings without a padding floor stay unchanged; it applies the same padding mechanism fixed for MUVERA in #1177. I reproduced both padding paths, added focused batch and exact-MaxSim checks, then ran `testpipeline.testtext.testsimilarity` with 11 tests passing and pre-commit.
