### PR TITLE
Improve late pooling configuration errors

### DIFF
--- a/docs/embeddings/configuration/vectors.md
+++ b/docs/embeddings/configuration/vectors.md
@@ -176,7 +176,8 @@ muvera:
 ```
 
 Settings to control the size of MUVERA fixed dimensional outputs. Default is 20 * 2^5 * 16 = 10,240 dimensions.
-Set `muvera` to `false` to disable it or `true` to use the default settings.
+Set `muvera` to `false` to disable it or `true` to use the default settings. `false` only makes sense when the multi-vector output
+is consumed directly, for example through `PoolingFactory`. Embeddings vectors require `muvera` or `lemur`.
 
 ### lemur
 ```yaml

--- a/src/python/txtai/models/pooling/late.py
+++ b/src/python/txtai/models/pooling/late.py
@@ -291,7 +291,8 @@ class LatePooling(Pooling):
             config = self.load(path, "artifact.metadata")
             params = ["query_token_id", "query_maxlen", "doc_token_id", "doc_maxlen"]
 
-        return [config.get(p) for p in params]
+        # Use defaults when the settings file is missing
+        return [config.get(p) for p in params] if config else [None] * len(params)
 
     def loadlinear(self, path, models):
         """

--- a/src/python/txtai/models/pooling/lemur.py
+++ b/src/python/txtai/models/pooling/lemur.py
@@ -209,6 +209,10 @@ class Lemur:
         with open(config, encoding="utf-8") as source:
             self.config = json.load(source)
 
+        # Encoder repos also have config.json and model.safetensors, check this is a LEMUR artifact
+        if "modeltype" not in self.config:
+            raise ValueError(f"{path} is not a LEMUR artifact, create one with LemurTrainer")
+
         self.model = LemurModel(**self.config).to(self.device)
         training = self.config.get("training", {})
         self.selectedepoch = training.get("selectedepoch")

--- a/src/python/txtai/vectors/base.py
+++ b/src/python/txtai/vectors/base.py
@@ -378,6 +378,9 @@ class Vectors:
         embeddings = self.encode(data, category)
 
         if embeddings is not None:
+            if embeddings.ndim != 2:
+                raise ValueError(f"Expected 2 dimensional vectors, produced {embeddings.ndim} dimensions")
+
             # Truncate embeddings, if necessary
             if self.dimensionality and self.dimensionality < embeddings.shape[1]:
                 embeddings = self.truncate(embeddings)

--- a/src/python/txtai/vectors/dense/huggingface.py
+++ b/src/python/txtai/vectors/dense/huggingface.py
@@ -42,4 +42,10 @@ class HFVectors(Vectors):
 
     def encode(self, data, category=None):
         # Encode data using vectors model
-        return self.model.encode(data, batch=self.encodebatch, category=category)
+        embeddings = self.model.encode(data, batch=self.encodebatch, category=category)
+
+        # Multi-vector outputs can't be indexed directly, a fixed dimensional encoder is required
+        if embeddings.ndim == 3:
+            raise ValueError("late interaction models require a fixed dimensional encoder (muvera or lemur) to produce embeddings vectors")
+
+        return embeddings

--- a/src/python/txtai/vectors/dense/huggingface.py
+++ b/src/python/txtai/vectors/dense/huggingface.py
@@ -42,10 +42,4 @@ class HFVectors(Vectors):
 
     def encode(self, data, category=None):
         # Encode data using vectors model
-        embeddings = self.model.encode(data, batch=self.encodebatch, category=category)
-
-        # Multi-vector outputs can't be indexed directly, a fixed dimensional encoder is required
-        if embeddings.ndim == 3:
-            raise ValueError("late interaction models require a fixed dimensional encoder (muvera or lemur) to produce embeddings vectors")
-
-        return embeddings
+        return self.model.encode(data, batch=self.encodebatch, category=category)

--- a/test/python/testmodels/testpooling.py
+++ b/test/python/testmodels/testpooling.py
@@ -221,6 +221,18 @@ class TestPooling(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     pool.centersettings(center, linear, True)
 
+    def testLateSettings(self):
+        """
+        Test late pooling defaults when the settings file is missing
+        """
+
+        pool = PoolingFactory.create({"path": "neuml/colbert-bert-tiny", "device": self.device, "modelargs": {"muvera": None}})
+
+        # A missing config_sentence_transformers.json (PyLate) or artifact.metadata (Stanford) reads as default settings
+        with patch.object(LatePooling, "load", return_value=None):
+            self.assertEqual(pool.settings("neuml/colbert-bert-tiny", [{"path": "1_Dense"}]), [None] * 4)
+            self.assertEqual(pool.settings("neuml/colbert-bert-tiny", None), [None] * 4)
+
     def testLemur(self):
         """
         Test late pooling with LEMUR fixed dimensional encoding
@@ -481,6 +493,17 @@ class TestPooling(unittest.TestCase):
             with self.subTest(shape=invalid[0].shape):
                 with self.assertRaisesRegex(ValueError, "each document must be a non-empty 2D token-vector array"):
                     lemur.documents(invalid)
+
+    def testLemurPathValidation(self):
+        """
+        Test LEMUR rejects a path that is not a LEMUR artifact
+        """
+
+        # An encoder repo also has config.json and model.safetensors
+        for model in ["neuml/colbert-bert-tiny", "neuml/pylate-bert-tiny"]:
+            with self.subTest(model=model):
+                with self.assertRaisesRegex(ValueError, "not a LEMUR artifact"):
+                    PoolingFactory.create({"path": model, "device": self.device, "modelargs": {"lemur": {"path": model}}})
 
     def testLemurStateValidation(self):
         """

--- a/test/python/testvectors/testdense/testhuggingface.py
+++ b/test/python/testvectors/testdense/testhuggingface.py
@@ -7,6 +7,7 @@ import unittest
 
 import numpy as np
 
+from txtai.embeddings import Embeddings
 from txtai.vectors import VectorsFactory
 
 
@@ -41,6 +42,16 @@ class TestHFVectors(unittest.TestCase):
         # Test shape of serialized embeddings
         with open(stream, "rb") as queue:
             self.assertEqual(np.load(queue).shape, (500, 768))
+
+    def testLateInteraction(self):
+        """
+        Test late interaction models require a fixed dimensional encoder to build an index
+        """
+
+        # Multi-vector outputs can't be indexed directly, muvera or lemur must be enabled
+        embeddings = Embeddings({"path": "neuml/colbert-bert-tiny", "backend": "numpy", "content": False, "gpu": False, "vectors": {"muvera": False}})
+        with self.assertRaisesRegex(ValueError, "fixed dimensional encoder"):
+            embeddings.index(["Short text.", "A considerably longer text exercises padding behavior.", "Third text."])
 
     def testText(self):
         """

--- a/test/python/testvectors/testdense/testhuggingface.py
+++ b/test/python/testvectors/testdense/testhuggingface.py
@@ -7,6 +7,7 @@ import unittest
 
 import numpy as np
 
+from txtai.embeddings import Embeddings
 from txtai.vectors import VectorsFactory
 
 
@@ -41,6 +42,15 @@ class TestHFVectors(unittest.TestCase):
         # Test shape of serialized embeddings
         with open(stream, "rb") as queue:
             self.assertEqual(np.load(queue).shape, (500, 768))
+
+    def testLateInteraction(self):
+        """
+        Test late interaction models produce 2 dimensional vectors
+        """
+
+        embeddings = Embeddings({"path": "neuml/colbert-bert-tiny", "backend": "numpy", "content": False, "gpu": False, "vectors": {"muvera": False}})
+        with self.assertRaisesRegex(ValueError, "Expected 2 dimensional vectors"):
+            embeddings.index(["Short text.", "A considerably longer text exercises padding behavior.", "Third text."])
 
     def testText(self):
         """

--- a/test/python/testvectors/testdense/testhuggingface.py
+++ b/test/python/testvectors/testdense/testhuggingface.py
@@ -7,7 +7,6 @@ import unittest
 
 import numpy as np
 
-from txtai.embeddings import Embeddings
 from txtai.vectors import VectorsFactory
 
 
@@ -42,16 +41,6 @@ class TestHFVectors(unittest.TestCase):
         # Test shape of serialized embeddings
         with open(stream, "rb") as queue:
             self.assertEqual(np.load(queue).shape, (500, 768))
-
-    def testLateInteraction(self):
-        """
-        Test late interaction models require a fixed dimensional encoder to build an index
-        """
-
-        # Multi-vector outputs can't be indexed directly, muvera or lemur must be enabled
-        embeddings = Embeddings({"path": "neuml/colbert-bert-tiny", "backend": "numpy", "content": False, "gpu": False, "vectors": {"muvera": False}})
-        with self.assertRaisesRegex(ValueError, "fixed dimensional encoder"):
-            embeddings.index(["Short text.", "A considerably longer text exercises padding behavior.", "Third text."])
 
     def testText(self):
         """


### PR DESCRIPTION
Three late-pooling configuration paths surfaced internal NumPy, `TypeError`, or `AttributeError` failures: `muvera: false` in an embeddings index, `lemur.path` aimed at an encoder repository, and a missing late settings file. This adds clear validation or defaults for those paths and documents that raw multi-vector output must be consumed directly, while every documented fixed-dimensional form still loads; it follows the settings-resolver work in #1196. I added three focused cases, then ran `testvectors.testdense.testhuggingface` with 6 tests passing, `testmodels.testpooling` with 24 passing, and pre-commit.
