### PR TITLE
Keep count() accurate after repeated deletes in GGML and IVFSparse

### DIFF
--- a/src/python/txtai/ann/dense/ggml.py
+++ b/src/python/txtai/ann/dense/ggml.py
@@ -220,9 +220,10 @@ class GGMLTensors:
 
         shape = utils.get_shape(self.data)
 
-        # Filter any index greater than size of array
-        ids = [x for x in ids if x < shape[1]]
-        self.deletes.extend(ids)
+        # Set index ids as deleted, ignoring ids outside the array and ids already marked deleted
+        for x in ids:
+            if x < shape[1] and x not in self.deletes:
+                self.deletes.append(x)
 
     def search(self, queries):
         """

--- a/src/python/txtai/ann/sparse/ivfsparse.py
+++ b/src/python/txtai/ann/sparse/ivfsparse.py
@@ -115,8 +115,11 @@ class IVFSparse(ANN):
         self.metadata()
 
     def delete(self, ids):
-        # Set index ids as deleted
-        self.deletes.extend(ids)
+        # Set index ids as deleted, ignoring ids that were never indexed and ids already marked deleted
+        size = self.size()
+        for x in ids:
+            if x < size and x not in self.deletes:
+                self.deletes.append(x)
 
     def search(self, queries, limit):
         results = []

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -185,6 +185,34 @@ class TestDense(unittest.TestCase):
 
         self.runTests("ggml")
 
+    def testGGMLDelete(self):
+        """
+        Test GGML backend deletes
+        """
+
+        ann = ANNFactory.create({"backend": "ggml"})
+
+        # Generate and index dummy data
+        data = np.random.rand(100, 256).astype(np.float32)
+        ann.index(data)
+
+        # Validate count
+        self.assertEqual(ann.count(), 100)
+
+        # Test delete
+        ann.delete([0])
+        self.assertEqual(ann.count(), 99)
+
+        # Deleting the same id again is a no-op for the count
+        ann.delete([0])
+        self.assertEqual(ann.count(), 99)
+
+        # Save updated index with deletes and reload
+        index = os.path.join(tempfile.gettempdir(), "ggml.deletes")
+        ann.save(index)
+        ann.load(index)
+        self.assertEqual(ann.count(), 99)
+
     def testGGMLQuantization(self):
         """
         Test GGML backend with quantization enabled

--- a/test/python/testann/testsparse.py
+++ b/test/python/testann/testsparse.py
@@ -77,9 +77,19 @@ class TestSparse(unittest.TestCase):
         ann.delete([0])
         self.assertEqual(ann.count(), count - 1)
 
+        # Deleting the same id again or an id that was never indexed is a no-op for the count
+        ann.delete([0])
+        ann.delete([count + 100])
+        self.assertEqual(ann.count(), count - 1)
+
         # Re-validate search results
         results = [x[0] for x in ann.search(append[0], 10)[0]]
         self.assertIn(insert.shape[0], results)
+
+        # Save and reload index with deletes
+        ann.save(path)
+        ann.load(path)
+        self.assertEqual(ann.count(), count - 1)
 
         # Close ANN
         ann.close()


### PR DESCRIPTION
GGML and `IVFSparse` `count()` drifted low after repeated deletes, and `IVFSparse` also counted unknown ids as deletions; the bad counts survived save and load. Both backends now ignore ids already marked deleted, `IVFSparse` ignores ids that were never indexed, and search behavior stays unchanged; this is the same delete-accounting shape as #1202. I added repeat-delete and reload coverage, then ran `testann.testdense` with 36 tests, 3 skipped, `testann.testsparse` with 7 tests passing, and pre-commit.
