### PR TITLE
fix(vectors): remove the sparse spool file when checkpointing is disabled

### DIFF
--- a/src/python/txtai/vectors/sparse/base.py
+++ b/src/python/txtai/vectors/sparse/base.py
@@ -2,6 +2,8 @@
 SparseVectors module
 """
 
+import os
+
 # Conditional import
 try:
     from scipy.sparse import csr_matrix, vstack
@@ -55,6 +57,10 @@ class SparseVectors(Vectors):
                 # Read in array batch
                 data = self.loadembeddings(queue)
                 embeddings = vstack((embeddings, data)) if embeddings is not None else data
+
+        # Remove temporary file (if checkpointing is disabled)
+        if not checkpoint:
+            os.remove(stream)
 
         # Return sparse array
         return (ids, dimensions, embeddings)

--- a/test/python/testvectors/testsparse/testsbert.py
+++ b/test/python/testvectors/testsparse/testsbert.py
@@ -3,7 +3,10 @@ Sparse Sentence Transformers module tests
 """
 
 import os
+import tempfile
 import unittest
+
+from unittest.mock import patch
 
 from txtai.vectors import SparseVectorsFactory
 from txtai.util import SparseArray
@@ -30,3 +33,20 @@ class TestSparseSTVectors(unittest.TestCase):
         # Test shape of serialized embeddings
         with open(stream, "rb") as queue:
             self.assertEqual(SparseArray().load(queue).shape, (1, 30522))
+
+    def testVectors(self):
+        """
+        Test building vectors with sentence-transformers vectors
+        """
+
+        model = SparseVectorsFactory.create({"method": "sentence-transformers", "path": "sparse-encoder-testing/splade-bert-tiny-nq"})
+
+        # Spool into an empty directory to check the temporary file doesn't outlive the call
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.object(tempfile, "tempdir", directory):
+                ids, dimension, embeddings = model.vectors([(0, "test", None)])
+
+            self.assertEqual(len(ids), 1)
+            self.assertEqual(dimension, 30522)
+            self.assertEqual(embeddings.shape, (1, 30522))
+            self.assertEqual(os.listdir(directory), [])


### PR DESCRIPTION
`SparseVectors.vectors()` overrides the base implementation but doesn't carry over its cleanup step, so the `.npy` spool file that `index()` writes is left behind on every call. `Vectors.vectors()` ends with `if not checkpoint: os.remove(stream)`; the sparse version just returns. Since `spool()` uses `NamedTemporaryFile(delete=False)`, nothing else removes it — every sparse index build leaves a full copy of the serialized embeddings in the temp dir, and `Sparse.encode()` in the scoring path goes through here too.

Added the same guarded remove, so the checkpoint case still keeps its file for restart. Verified both paths locally: with a checkpoint directory the file is preserved and a second run is served from it, without one the temp dir is empty afterwards. New test spools into an empty directory and asserts nothing is left; it fails on master with `['tmp7dloe8t7.npy'] != []`.
