### PR TITLE
Keep the archive working directory alive when saving a loaded index

### DIFF
--- a/src/python/txtai/embeddings/base.py
+++ b/src/python/txtai/embeddings/base.py
@@ -549,6 +549,9 @@ class Embeddings:
         if cloud:
             path = cloud.load(path)
 
+        # Reset archive since this replaces the current index
+        self.archive = None
+
         # Check if this is an archive file and extract
         path, apath = self.checkarchive(path)
         if apath:
@@ -931,7 +934,8 @@ class Embeddings:
         """
 
         # Create archive instance, if necessary
-        self.archive = ArchiveFactory.create()
+        if not self.archive:
+            self.archive = ArchiveFactory.create()
 
         # Check if path is an archive file
         if self.archive.isarchive(path):

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -48,6 +48,45 @@ class TestEmbeddings(unittest.TestCase):
         if cls.embeddings:
             cls.embeddings.close()
 
+    def testArchive(self):
+        """
+        Test saving and loading a compressed index archive
+        """
+
+        # Index data with sparse keyword vectors and content
+        embeddings = Embeddings({"keyword": True, "content": True})
+        embeddings.index([(uid, text, None) for uid, text in enumerate(self.data)])
+
+        # Generate temp file paths
+        archive = os.path.join(tempfile.gettempdir(), "embeddings.archive.tar.gz")
+        index = os.path.join(tempfile.gettempdir(), "embeddings.archive")
+
+        # Save to an archive, load it and save back to the same archive
+        embeddings.save(archive)
+        embeddings.close()
+
+        embeddings = Embeddings().load(archive)
+        self.assertTrue(embeddings.exists(archive))
+        embeddings.save(archive)
+
+        # Save to a directory, update data and save to the archive again
+        embeddings.save(index)
+        embeddings.upsert([(0, "Feel good story: baby panda born", None)])
+        embeddings.save(archive)
+        embeddings.close()
+
+        # Directory has the original data
+        embeddings = Embeddings().load(index)
+        self.assertEqual(embeddings.count(), len(self.data))
+        self.assertEqual(embeddings.search("lottery ticket", 1)[0]["id"], "4")
+        embeddings.close()
+
+        # Archive has the updated data
+        embeddings = Embeddings().load(archive)
+        self.assertEqual(embeddings.count(), len(self.data))
+        self.assertEqual(embeddings.search("feel good story", 1)[0]["id"], "0")
+        embeddings.close()
+
     def testAutoId(self):
         """
         Test auto id generation


### PR DESCRIPTION
An index loaded from a `.tar.gz` or `.zip` archive could not be saved again to the same archive, another archive, or a directory when keyword or content storage kept SQLite connections open in the extracted working directory. This keeps the current archive working directory alive across `save()` and `exists()`, while `load()` still resets it when replacing the index; fresh non-archive indexes and dense-only archive behavior stay unchanged. I added a focused test covering save-back, `exists()`, save-to-directory, `upsert()`, and reload, then ran it with pre-commit and the existing embeddings tests; the new test passes and nothing else changed.
