### PR TITLE
Key the vectors model cache by configuration

### DIFF
--- a/src/python/txtai/vectors/base.py
+++ b/src/python/txtai/vectors/base.py
@@ -96,9 +96,12 @@ class Vectors:
             model
         """
 
-        # Cache key is the model path plus settings that change the loaded model. Other settings share a single load.
-        config = {"path": path, "method": self.config.get("method"), "vectors": self.config.get("vectors", {})}
-        key = json.dumps(config, sort_keys=True, default=str)
+        # Build a cache key from settings that change the loaded model when a configuration is present.
+        if self.config:
+            config = {"path": path, "method": self.config.get("method"), "vectors": self.config.get("vectors", {})}
+            key = json.dumps(config, sort_keys=True, default=str)
+        else:
+            key = path
 
         # Check if model is cached
         if self.models and key in self.models:

--- a/src/python/txtai/vectors/base.py
+++ b/src/python/txtai/vectors/base.py
@@ -96,16 +96,22 @@ class Vectors:
             model
         """
 
+        # Cache key is the configuration that determines how a model is loaded, not the path alone
+        select = ["method", "gpu", "tokenizer", "maxlength", "instructions"]
+        config = {k: v for k, v in self.config.items() if k in select}
+        config["path"], config["vectors"] = path, self.config.get("vectors", {})
+        key = json.dumps(config, sort_keys=True, default=str)
+
         # Check if model is cached
-        if self.models and path in self.models:
-            return self.models[path]
+        if self.models and key in self.models:
+            return self.models[key]
 
         # Create new model
         model = self.loadmodel(path)
 
         # Store model in cache
         if self.models is not None and path:
-            self.models[path] = model
+            self.models[key] = model
 
         return model
 

--- a/src/python/txtai/vectors/base.py
+++ b/src/python/txtai/vectors/base.py
@@ -96,10 +96,8 @@ class Vectors:
             model
         """
 
-        # Cache key is the configuration that determines how a model is loaded, not the path alone
-        select = ["method", "gpu", "tokenizer", "maxlength", "instructions"]
-        config = {k: v for k, v in self.config.items() if k in select}
-        config["path"], config["vectors"] = path, self.config.get("vectors", {})
+        # Cache key is the model path plus settings that change the loaded model. Other settings share a single load.
+        config = {"path": path, "method": self.config.get("method"), "vectors": self.config.get("vectors", {})}
         key = json.dumps(config, sort_keys=True, default=str)
 
         # Check if model is cached

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -594,6 +594,36 @@ class TestEmbeddings(unittest.TestCase):
         # Close embeddings
         embeddings.close()
 
+    def testSubindexVectors(self):
+        """
+        Test subindexes with the same model path and different vectors settings
+        """
+
+        # Build data array
+        data = [(uid, text, None) for uid, text in enumerate(self.data)]
+
+        # Subindexes share a models cache. The same model path with different vectors settings must load separate models.
+        path = "neuml/colbert-bert-tiny"
+        embeddings = Embeddings(
+            {
+                "defaults": False,
+                "indexes": {
+                    "index1": {"path": path, "vectors": {"muvera": {"repetitions": 1}}},
+                    "index2": {"path": path, "vectors": {"muvera": {"repetitions": 2}}},
+                },
+            }
+        )
+        embeddings.index(data)
+
+        # MUVERA output dimensions = repetitions * 2^5 * 16
+        self.assertEqual(embeddings.transform("feel good story", index="index1").shape, (512,))
+        self.assertEqual(embeddings.transform("feel good story", index="index2").shape, (1024,))
+        self.assertEqual(embeddings.indexes["index1"].config["dimensions"], 512)
+        self.assertEqual(embeddings.indexes["index2"].config["dimensions"], 1024)
+
+        # Close embeddings
+        embeddings.close()
+
     def testTerms(self):
         """
         Test extracting keyword terms from queries

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -620,6 +620,23 @@ class TestEmbeddings(unittest.TestCase):
         self.assertEqual(embeddings.transform("feel good story", index="index2").shape, (1024,))
         self.assertEqual(embeddings.indexes["index1"].config["dimensions"], 512)
         self.assertEqual(embeddings.indexes["index2"].config["dimensions"], 1024)
+        self.assertIsNot(embeddings.indexes["index1"].model.model, embeddings.indexes["index2"].model.model)
+
+        # Close embeddings
+        embeddings.close()
+
+        # Per-encode settings share the same loaded model
+        embeddings = Embeddings(
+            {
+                "defaults": False,
+                "indexes": {
+                    "index1": {"path": path, "maxlength": 32, "vectors": {"muvera": {"repetitions": 1}}},
+                    "index2": {"path": path, "maxlength": 64, "vectors": {"muvera": {"repetitions": 1}}},
+                },
+            }
+        )
+        embeddings.index(data)
+        self.assertIs(embeddings.indexes["index1"].model.model, embeddings.indexes["index2"].model.model)
 
         # Close embeddings
         embeddings.close()


### PR DESCRIPTION
Subindexes using the same encoder path shared one cached model, so later subindexes silently ignored their own `vectors` settings. This keys the cache by the path and load-time configuration, while identical configurations still share a single model load. I reproduced the cross-subindex reuse, added a focused MUVERA settings test, then ran the Hugging Face vectors module with 5 tests passing and pre-commit.
