### PR TITLE
Save empty keyword and content indexes without errors

### DIFF
--- a/src/python/txtai/database/embedded.py
+++ b/src/python/txtai/database/embedded.py
@@ -31,6 +31,9 @@ class Embedded(RDBMS):
         self.path = path
 
     def save(self, path):
+        # Initialize connection if not open
+        self.initialize()
+
         # Temporary database
         if not self.path:
             # Save temporary database

--- a/src/python/txtai/embeddings/base.py
+++ b/src/python/txtai/embeddings/base.py
@@ -136,7 +136,7 @@ class Embeddings:
                 self.ann.index(embeddings)
 
             # Save indexids-ids mapping for indexes with no database, except when this is a reindex
-            if ids and not reindex and not self.database:
+            if ids is not None and not reindex and not self.database:
                 self.ids = self.createids(ids)
 
         # Index scoring, if necessary

--- a/src/python/txtai/scoring/terms.py
+++ b/src/python/txtai/scoring/terms.py
@@ -286,6 +286,9 @@ class Terms:
             path: path to write terms database
         """
 
+        # Initialize database, if necessary
+        self.initialize()
+
         # Clear documents table
         self.cursor.execute(Terms.DELETE_DOCUMENTS)
 

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -153,6 +153,27 @@ class TestEmbeddings(unittest.TestCase):
         embeddings.upsert([])
         self.assertIsNotNone(embeddings.ann)
 
+    def testEmptySave(self):
+        """
+        Test saving an empty index
+        """
+
+        for content in [False, True]:
+            # Keyword index, no data ever indexed
+            embeddings = Embeddings({"keyword": True, "content": content})
+            embeddings.index([])
+
+            # Generate temp file path
+            index = os.path.join(tempfile.gettempdir(), f"embeddings.emptysave.{content}")
+
+            # Test save/load
+            embeddings.save(index)
+            embeddings.load(index)
+
+            # Validate index is still empty
+            self.assertEqual(embeddings.count(), 0)
+            self.assertEqual(embeddings.search("test"), [])
+
     def testEmptyString(self):
         """
         Test empty string indexing

--- a/test/python/testscoring/testkeyword.py
+++ b/test/python/testscoring/testkeyword.py
@@ -147,6 +147,23 @@ class TestKeyword(unittest.TestCase):
         self.assertEqual(scoring.count(), 0)
         self.assertEqual(scoring.search("bear", 1), [])
 
+    def testTermsEmptySave(self):
+        """
+        Test saving and loading a terms index with nothing indexed
+        """
+
+        for method in ["bm25", "tfidf"]:
+            config = {"method": method, "terms": True}
+
+            # No documents ever inserted - term database never initialized
+            scoring = ScoringFactory.create(config)
+            scoring.index([])
+
+            # Save/load and validate index is still empty
+            scoring = self.save(scoring, config, f"scoring.{method}.empty")
+            self.assertEqual(scoring.count(), 0)
+            self.assertEqual(scoring.search("bear", 1), [])
+
     def testDeleteUnknownId(self):
         """
         Test that deleting an id that was never indexed is a no-op, not a crash


### PR DESCRIPTION
`index([])` followed by `save()` raised `AttributeError` for keyword or hybrid scoring and for `content: True` because the SQLite connection is created on first insert. This initializes the schemas during `save()` and writes the empty index-id mapping, so an empty keyword index with or without content reloads with `count()` returning 0, while populated indexes save exactly as before; it completes the empty Terms save side of #1143's search fix. I added focused empty-save tests, then ran the keyword module with 12 tests passing and pre-commit.
