### PR TITLE
fix(workflow): add request timeout to ServiceTask

### DIFF
--- a/src/python/txtai/workflow/task/service.py
+++ b/src/python/txtai/workflow/task/service.py
@@ -19,7 +19,7 @@ class ServiceTask(Task):
     Task to runs requests against remote service urls.
     """
 
-    def register(self, url=None, method=None, params=None, batch=True, extract=None):
+    def register(self, url=None, method=None, params=None, batch=True, extract=None, timeout=30):
         """
         Adds service parameters to task. Checks if required dependencies are installed.
 
@@ -29,6 +29,7 @@ class ServiceTask(Task):
             params: default query parameters
             batch: if True, all elements are passed in a single batch request, otherwise a service call is executed per element
             extract: list of sections to extract from response
+            timeout: request timeout in seconds, defaults to 30
         """
 
         if not XML_TO_DICT:
@@ -42,6 +43,9 @@ class ServiceTask(Task):
 
         # If True, all elements are passed in a single batch request, otherwise a service call is executed per element
         self.batch = batch
+
+        # Request timeout in seconds. Prevents a slow or unresponsive endpoint from blocking the workflow indefinitely.
+        self.timeout = timeout
 
         # Save sections to extract. Supports both a single string and a hierarchical list of sections.
         self.extract = extract
@@ -83,9 +87,9 @@ class ServiceTask(Task):
 
         # Run request
         if self.method and self.method.lower() == "get":
-            response = requests.get(self.url, params=params)
+            response = requests.get(self.url, params=params, timeout=self.timeout)
         else:
-            response = requests.post(self.url, json=params)
+            response = requests.post(self.url, json=params, timeout=self.timeout)
 
         # Parse data based on content-type
         mimetype = response.headers["Content-Type"].split(";")[0]

--- a/test/python/testapi/testapiworkflow.py
+++ b/test/python/testapi/testapiworkflow.py
@@ -5,12 +5,15 @@ Workflow API module tests
 import json
 import os
 import tempfile
+import time
 import unittest
 
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from multiprocessing.pool import ThreadPool
 from threading import Thread
 from unittest.mock import patch
+
+import requests
 
 from fastapi.testclient import TestClient
 
@@ -91,6 +94,15 @@ workflow:
               extract: row
               params:
                 text:
+
+    slow:
+        tasks:
+            - task: service
+              url: http://127.0.0.1:8001/slow
+              method: get
+              timeout: 1
+              params:
+                text:
 """
 
 
@@ -103,6 +115,10 @@ class RequestHandler(BaseHTTPRequestHandler):
         """
         GET request handler.
         """
+
+        if self.path.startswith("/slow"):
+            # Sleep longer than the client timeout to force a read timeout
+            time.sleep(2)
 
         self.send_response(200)
 
@@ -229,6 +245,15 @@ class TestWorkflow(unittest.TestCase):
 
         self.assertEqual(len(results), 1)
         self.assertEqual(len(results[0]), 1)
+
+    def testServiceTimeout(self):
+        """
+        Test workflow with ServiceTask GET that bounds a slow endpoint via a timeout
+        """
+
+        text = "This is a test sentence. And another sentence to split."
+        with self.assertRaises(requests.exceptions.Timeout):
+            self.client.post("workflow", json={"name": "slow", "elements": [text]})
 
     def testWorkflowLabels(self):
         """


### PR DESCRIPTION
Fixes #1225.

### Problem

`ServiceTask` calls `requests.get` / `requests.post` with no `timeout=`. Since `requests` has no default timeout, a workflow whose `ServiceTask` points at a slow or unresponsive endpoint blocks **forever**, and `register(...)` exposed no knob to bound it.

### Fix (minimal, follows existing precedent)

- `ServiceTask.register(...)` gains a `timeout=30` parameter, stored as `self.timeout`.
- Both `requests.get` and `requests.post` now pass `timeout=self.timeout`.

The default and shape mirror the in-repo precedent in the URLRetrieve pipeline (`src/python/txtai/pipeline/data/urlretrieve.py:30`, `timeout=30`). Because `TaskFactory.create` does `TaskFactory.get(task)(**config)`, a `timeout:` key in workflow YAML flows through `Task.__init__` straight to `register(timeout=...)` — so it's configurable per task with a safe default.

### Test

Added `testServiceTimeout` to `test/python/testapi/testapiworkflow.py`: a `/slow` GET branch (`time.sleep(2)`) plus a `slow` workflow with `timeout: 1`, asserting `requests.exceptions.Timeout` is raised.

Validated the real `ServiceTask` class against a live local HTTP server that sleeps 2s with client `timeout=1`:
- **Before:** `register() got an unexpected keyword argument 'timeout'` — no way to bound the call.
- **After:** `requests.exceptions.Timeout` raised after ~1.00s.

`black --check` and `pylint` are clean (10.00/10 on both touched files).

> Note: I couldn't run the full `testapiworkflow` suite locally — its `setUpClass` builds the whole API (sentence-transformers + a labels model, multi-GB downloads) which isn't available in my environment. The added test is syntactically valid and correctly wired (config→`register` path traced); its green run should happen in CI. The standalone real-class reproduction above exercises the actual code path.
