### PR TITLE
Select the top documents in LateEncoder by the document axis

### DIFF
--- a/src/python/txtai/pipeline/text/lateencoder.py
+++ b/src/python/txtai/pipeline/text/lateencoder.py
@@ -109,7 +109,7 @@ class LateEncoder(Pipeline):
         scores = scores.cpu().numpy()
 
         # Get top n matching indices and scores
-        indices = np.argpartition(-scores, limit if limit and limit < scores.shape[0] else scores.shape[0] - 1)[:, :limit]
+        indices = np.argpartition(-scores, limit if limit and limit < scores.shape[1] else scores.shape[1] - 1)[:, :limit]
         scores = np.take_along_axis(scores, indices, axis=1)
 
         # argpartition doesn't order within the top n - sort each row by score descending

--- a/src/python/txtai/pipeline/text/similarity.py
+++ b/src/python/txtai/pipeline/text/similarity.py
@@ -57,7 +57,7 @@ class Similarity(Labels):
             return self.crossencoder(query, texts, multilabel, labels=labels)
 
         if self.lateencoder:
-            return self.lateencoder(query, texts)
+            return self.lateencoder(query, texts, **kwargs)
 
         # Call Labels pipeline for texts using input query as the candidate label
         scores = super().__call__(texts, [query] if isinstance(query, str) else query, multilabel, **kwargs)

--- a/test/python/testpipeline/testtext/testsimilarity.py
+++ b/test/python/testpipeline/testtext/testsimilarity.py
@@ -4,7 +4,7 @@ Similarity module tests
 
 import unittest
 
-from txtai.pipeline import LateEncoder, Similarity
+from txtai.pipeline import Similarity
 
 
 class TestSimilarity(unittest.TestCase):
@@ -135,15 +135,15 @@ class TestSimilarity(unittest.TestCase):
         Test late-encoder similarity model with a limit returns the top scoring results
         """
 
-        lateencoder = LateEncoder("neuml/colbert-bert-tiny")
+        similarity = Similarity("neuml/colbert-bert-tiny", lateencode=True)
         queries = ["Who won the lottery?", "Where did an iceberg collapse?"]
 
         for query in queries:
-            results = lateencoder(query, self.data, limit=3)
+            results = similarity(query, self.data, limit=3)
             scores = [score for _, score in results]
 
             # Limited results must match the top results of the unlimited call, sorted by score descending
-            self.assertEqual([uid for uid, _ in results], [uid for uid, _ in lateencoder(query, self.data)[:3]])
+            self.assertEqual([uid for uid, _ in results], [uid for uid, _ in similarity(query, self.data)[:3]])
             self.assertEqual(scores, sorted(scores, reverse=True))
 
     def testLateEncoderPadding(self):

--- a/test/python/testpipeline/testtext/testsimilarity.py
+++ b/test/python/testpipeline/testtext/testsimilarity.py
@@ -4,7 +4,7 @@ Similarity module tests
 
 import unittest
 
-from txtai.pipeline import Similarity
+from txtai.pipeline import LateEncoder, Similarity
 
 
 class TestSimilarity(unittest.TestCase):
@@ -129,6 +129,22 @@ class TestSimilarity(unittest.TestCase):
             alone = dict(similarity(query, self.data))
             for uid, score in scores:
                 self.assertAlmostEqual(score, alone[uid], places=4)
+
+    def testLateEncoderLimit(self):
+        """
+        Test late-encoder similarity model with a limit returns the top scoring results
+        """
+
+        lateencoder = LateEncoder("neuml/colbert-bert-tiny")
+        queries = ["Who won the lottery?", "Where did an iceberg collapse?"]
+
+        for query in queries:
+            results = lateencoder(query, self.data, limit=3)
+            scores = [score for _, score in results]
+
+            # Limited results must match the top results of the unlimited call, sorted by score descending
+            self.assertEqual([uid for uid, _ in results], [uid for uid, _ in lateencoder(query, self.data)[:3]])
+            self.assertEqual(scores, sorted(scores, reverse=True))
 
     def testLateEncoderPadding(self):
         """


### PR DESCRIPTION
`LateEncoder` with `limit` smaller than the number of texts returned the best match followed by arbitrary texts because the partition index was taken from the query axis. This selects the partition index from the document axis, while results for `limit=None` or a limit at least as large as the text count stay unchanged. I reproduced the wrong top-three selection, added a focused test, then ran the full similarity module and pre-commit, all passing.
