### PR TITLE
docs: fix dead method anchors on the Embeddings methods page

### DIFF
--- a/docs/embeddings/configuration/cloud.md
+++ b/docs/embeddings/configuration/cloud.md
@@ -2,7 +2,7 @@
 
 The following describes parameters used to sync indexes with cloud storage. Cloud object storage, the [Hugging Face Hub](https://huggingface.co/models) and custom providers are all supported.
 
-Parameters are set via the [embeddings.load](../../methods/#txtai.embeddings.base.Embeddings.load) and [embeddings.save](../../methods/#txtai.embeddings.base.Embeddings.save) methods.
+Parameters are set via the [embeddings.load](../../methods/#txtai.embeddings.Embeddings.load) and [embeddings.save](../../methods/#txtai.embeddings.Embeddings.save) methods.
 
 ## provider
 ```yaml

--- a/docs/embeddings/configuration/index.md
+++ b/docs/embeddings/configuration/index.md
@@ -1,6 +1,6 @@
 # Configuration
 
-The following describes available embeddings configuration. These parameters are set in the [Embeddings constructor](../methods#txtai.embeddings.base.Embeddings.__init__) via either the `config` parameter or as keyword arguments.
+The following describes available embeddings configuration. These parameters are set in the [Embeddings constructor](../methods#txtai.embeddings.Embeddings.__init__) via either the `config` parameter or as keyword arguments.
 
 Configuration is designed to be optional and set only when needed. Out of the box, sensible defaults are picked to get up and running fast. For example:
 

--- a/docs/embeddings/index.md
+++ b/docs/embeddings/index.md
@@ -77,7 +77,7 @@ The index method takes an iterable and supports the following formats for each e
 
 - `data`
 
-Single element to index. In this case, unique id's will automatically be generated. Note that for generated id's, [upsert](methods/#txtai.embeddings.base.Embeddings.upsert) and [delete](methods/#txtai.embeddings.base.Embeddings.delete) calls require a separate search to get the target ids.
+Single element to index. In this case, unique id's will automatically be generated. Note that for generated id's, [upsert](methods/#txtai.embeddings.Embeddings.upsert) and [delete](methods/#txtai.embeddings.Embeddings.delete) calls require a separate search to get the target ids.
 
 When the data field is a dictionary, text is passed via the `text` key, binary objects via the `object` key. Note that [content](configuration/database#content) must be enabled to store metadata and [objects](configuration/database#objects) to store binary object data. The `id` and `tags` keys will be extracted, if provided.
 
@@ -102,7 +102,7 @@ Both natural language and SQL queries are supported. More information can be fou
 
 ## Resource management
 
-Embeddings databases are context managers. The following blocks automatically [close](methods/#txtai.embeddings.base.Embeddings.close) and free resources upon completion.
+Embeddings databases are context managers. The following blocks automatically [close](methods/#txtai.embeddings.Embeddings.close) and free resources upon completion.
 
 ```python
 # Create a new Embeddings database, index data and save

--- a/docs/embeddings/indexing.md
+++ b/docs/embeddings/indexing.md
@@ -27,7 +27,7 @@ The columns used for text, object and JSON data storage are set via [column conf
 
 ## Index vs Upsert
 
-Data is loaded into an index with either an [index](../methods#txtai.embeddings.base.Embeddings.index) or [upsert](../methods#txtai.embeddings.base.Embeddings.upsert) call.
+Data is loaded into an index with either an [index](../methods#txtai.embeddings.Embeddings.index) or [upsert](../methods#txtai.embeddings.Embeddings.upsert) call.
 
 ```python
 embeddings.index([(uid, text, None) for uid, text in enumerate(data)])
@@ -38,7 +38,7 @@ The `index` call will build a brand new index replacing an existing one. `upsert
 
 ## Save
 
-Indexes can be stored in a directory using the [save](../methods/#txtai.embeddings.base.Embeddings.save) method.
+Indexes can be stored in a directory using the [save](../methods/#txtai.embeddings.Embeddings.save) method.
 
 ```python
 embeddings.save("/path/to/save")
@@ -58,7 +58,7 @@ embeddings.save("/path/to/save/index.tar.gz", cloud={...})
 
 This is especially useful when running in a serverless context or otherwise running on temporary compute. Cloud storage is only supported with compressed indexes.
 
-Embeddings indexes can be restored using the [load](../methods/#txtai.embeddings.base.Embeddings.load) method.
+Embeddings indexes can be restored using the [load](../methods/#txtai.embeddings.Embeddings.load) method.
 
 ```python
 embeddings.load("/path/to/load")
@@ -66,7 +66,7 @@ embeddings.load("/path/to/load")
 
 ## Delete
 
-Content can be removed from the index with the [delete](../methods#txtai.embeddings.base.Embeddings.delete) method. This method takes a list of ids to delete.
+Content can be removed from the index with the [delete](../methods#txtai.embeddings.Embeddings.delete) method. This method takes a list of ids to delete.
 
 ```python
 embeddings.delete(ids)
@@ -74,7 +74,7 @@ embeddings.delete(ids)
 
 ## Reindex
 
-When [content storage](../configuration/database#content) is enabled, [reindex](../methods#txtai.embeddings.base.Embeddings.reindex) can be called to rebuild the index with new settings. For example, the backend can be switched from faiss to hnsw or the vector model can be updated. This prevents having to go back to the original raw data. 
+When [content storage](../configuration/database#content) is enabled, [reindex](../methods#txtai.embeddings.Embeddings.reindex) can be called to rebuild the index with new settings. For example, the backend can be switched from faiss to hnsw or the vector model can be updated. This prevents having to go back to the original raw data. 
 
 ```python
 embeddings.reindex(path="sentence-transformers/all-MiniLM-L6-v2", backend="hnsw")

--- a/docs/embeddings/query.md
+++ b/docs/embeddings/query.md
@@ -14,7 +14,7 @@ embeddings.search("feel good story")
 embeddings.search("wildlife")
 ```
 
-The queries above [search](../methods#txtai.embeddings.base.Embeddings.search) the index for similarity matches on `feel good story` and `wildlife`. If content storage is enabled, a list of `{**query columns}` is returned. Otherwise, a list of `(id, score)` tuples are returned.
+The queries above [search](../methods#txtai.embeddings.Embeddings.search) the index for similarity matches on `feel good story` and `wildlife`. If content storage is enabled, a list of `{**query columns}` is returned. Otherwise, a list of `(id, score)` tuples are returned.
 
 ## SQL
 


### PR DESCRIPTION
## What does this PR do?

Fixes 13 in-page anchors pointing at the `txtai.embeddings.base.Embeddings.<method>` slug family. The methods page (`docs/embeddings/methods.md`) documents `::: txtai.embeddings.Embeddings`, so its generated heading ids are `txtai.embeddings.Embeddings.<method>` — every link using the `base.` form (5 pages: `embeddings/indexing.md`, `embeddings/query.md`, `embeddings/index.md`, `embeddings/configuration/cloud.md`, `embeddings/configuration/index.md`) scrolled nowhere on the published site. Verified the live ids at neuml.github.io/txtai/embeddings/methods/ (e.g. `txtai.embeddings.Embeddings.index`, `.save`, `.load`, `.delete`, `.reindex`, `.search`, `.close`, `.__init__`).

The correct form was already used in `docs/agent/configuration.md:80`, which is what these files now match.

## Why is this change needed?

All 13 cross-reference links were dead on the published docs site.

## Related Issue

None (docs-only fix).
