### PR TITLE
Keep subindex ids aligned across nullable documents

### DIFF
--- a/src/python/txtai/embeddings/index/indexes.py
+++ b/src/python/txtai/embeddings/index/indexes.py
@@ -118,12 +118,17 @@ class Indexes:
         for _, document, _ in documents:
             # Add to documents collection if text or object field is set
             parent = document
+            hasfield = True
             if isinstance(parent, dict):
+                hasfield = self.text in parent or self.object in parent
                 parent = parent.get(self.text, document.get(self.object))
 
             # Add if field is available or top-level indexing is disabled
             if parent is not None or not self.indexing:
                 batch.append((index, document, None))
+
+            # Increment if document consumed a top-level index slot
+            if hasfield or not self.indexing:
                 index += 1
 
         # Add filtered documents batch

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -7,12 +7,38 @@ import os
 import tempfile
 import unittest
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
 
-from txtai.embeddings import Embeddings, Reducer
+from txtai.embeddings import Embeddings, Indexes, Reducer
 from txtai.serialize import SerializeFactory
+
+
+class TestIndexes(unittest.TestCase):
+    """
+    Subindex tests.
+    """
+
+    def testNoneTextIndexSync(self):
+        """
+        Test nullable documents don't shift subindex ids
+        """
+
+        embeddings = SimpleNamespace(config={}, model=True, scoring=None)
+        indexes = Indexes(embeddings, {})
+        documents = [
+            ("d0", {"text": "alpha content"}, None),
+            ("d1", {"text": None}, None),
+            ("d2", {"text": "gamma content"}, None),
+        ]
+
+        indexes.insert(documents, index=0)
+        queued = list(indexes.documents)
+        indexes.documents.close()
+
+        self.assertEqual([index for index, _, _ in queued], [0, 2])
 
 
 # pylint: disable=R0904


### PR DESCRIPTION
## Summary

`Indexes.insert()` advanced its parent index id only when a document was queued for a subindex. `Transform.stream()`, however, consumes a top-level vector slot whenever a dictionary contains the configured text or object key, even when that value is `None`.

With subindexes enabled, a nullable document therefore caused every later subindex document in the batch to be associated with the preceding vector id. For example, `d2` in `[d0, {"text": None}, d2]` was queued at parent index 1 even though its top-level vector slot is 2. This can silently attach subindex search results to the wrong parent document.

## Fix

Track key presence separately from whether the resolved value is eligible for subindexing. Nullable content is still skipped, but its consumed top-level slot now advances the parent index id. This uses the same slot-consumption rule as `Transform.stream()` and the graph alignment fix in #1136.

## Testing

Added `TestIndexes.testNoneTextIndexSync`, which queues a nullable document between two valid documents and verifies that the valid documents retain parent ids 0 and 2.

- Confirmed the assertion fails before the fix: the queued ids are `[0, 1]`.
- `python -m unittest testembeddings.TestIndexes.testNoneTextIndexSync -v`
- `black --check src/python/txtai/embeddings/index/indexes.py test/python/testembeddings.py`
- `pylint -d import-error -d duplicate-code -d too-many-positional-arguments src/python/txtai/embeddings/index/indexes.py test/python/testembeddings.py` (10.00/10)

## AI disclosure

Prepared with Codex assistance. I reviewed every changed line, reproduced the id mismatch against the exact current `master` source, and ran the tests and linters above locally before opening this PR.
