### PR TITLE
Fix Transform.stream() yielding a None text value into the encoder

### DIFF
--- a/src/python/txtai/embeddings/index/transform.py
+++ b/src/python/txtai/embeddings/index/transform.py
@@ -147,10 +147,10 @@ class Transform:
                 if not self.indexing and not document[1].get(self.text):
                     document[1][self.text] = str(document[0])
 
-                if self.text in document[1]:
+                if document[1].get(self.text) is not None:
                     yield (document[0], document[1][self.text], document[2])
                     offset += 1
-                elif self.object in document[1]:
+                elif document[1].get(self.object) is not None:
                     yield (document[0], document[1][self.object], document[2])
                     offset += 1
             else:

--- a/test/python/testembeddings.py
+++ b/test/python/testembeddings.py
@@ -226,6 +226,19 @@ class TestEmbeddings(unittest.TestCase):
         self.embeddings.index([(0, {"text": ""}, None)])
         self.assertTrue(self.embeddings.search("test"))
 
+    def testNoneText(self):
+        """
+        Test dict documents where the text field is present but set to None
+        """
+
+        # None text mixed with real text
+        self.embeddings.index([(0, {"text": "alpha content"}, None), (1, {"text": None}, None), (2, {"text": "gamma content"}, None)])
+
+        # Only the two documents with real text should be indexed
+        self.assertEqual(self.embeddings.count(), 2)
+        self.assertEqual(self.embeddings.search("alpha content", 1)[0][0], 0)
+        self.assertEqual(self.embeddings.search("gamma content", 1)[0][0], 2)
+
     def testExternal(self):
         """
         Test embeddings backed by external vectors


### PR DESCRIPTION
Transform.stream() decides whether to vectorize a dict document by checking whether `text` (or `object`) is a key, not whether it has a value. A row with `{"text": None}` (routine with DB- or pandas-sourced documents that have a nullable column) still gets yielded into vectorization, so a real encoder receives a literal `None` and raises. By the time that happens, stream() has already committed the earlier documents in the batch to the database/scoring/graph inserts, so the crash leaves the index half-built: content committed, no ANN ever built, and every later `search()` fails with an unrelated `IndexNotFoundError`.

Graph, TFIDF, RDBMS and Indexes all resolve the same field with `document.get(text, document.get(object))` and check `is not None`. stream() was the one place still using key presence, and switching it to the same check keeps the vectorization offset in sync with what everything downstream already assumes.

You asked in #1136 for an example that fails via the Embeddings interface before revisiting that area; this is one, though the fix sits one level up from where #1136 patched it. Doesn't touch indexes.py, so it's independent of #1230.

Added `testNoneText`: indexes a None-text doc between two real ones. The new test is the one that catches this, main raises the encoder's ValueError on it. Also ran the rest of `testembeddings.py`, 27 of 33 (the other 6 need vectors/graph extras I didn't install, unrelated to this), plus black and pylint on both changed files.
