### PR TITLE
fix: surface real import failure in agent placeholder error message (…

### DIFF
--- a/src/python/txtai/agent/__init__.py
+++ b/src/python/txtai/agent/__init__.py
@@ -8,5 +8,10 @@ try:
     from .factory import ProcessFactory
     from .model import PipelineModel
     from .tool import *
-except ImportError:
+except ImportError as e:
     from .placeholder import Agent
+
+    # Preserve the underlying import failure so the placeholder can surface
+    # the real cause (e.g. mcpadapt/mcp incompatibility) instead of always
+    # blaming a missing smolagents install. See issue #1161.
+    Agent._import_error = str(e)

--- a/src/python/txtai/agent/placeholder.py
+++ b/src/python/txtai/agent/placeholder.py
@@ -5,12 +5,22 @@ Placeholder module
 
 class Agent:
     """
-    Agent placeholder stub for when smolagents isn't installed
+    Agent placeholder stub for when agent dependencies aren't installed
     """
+
+    # Set by txtai.agent.__init__ when the conditional import fails.
+    # Contains the underlying ImportError message so users see the real
+    # cause (e.g. mcpadapt/mcp incompatibility) instead of always being told
+    # smolagents is missing. See issue #1161.
+    _import_error = None
 
     def __init__(self, *args, **kwargs):
         """
-        Raises an exception that smolagents isn't installed.
+        Raises an exception with the actual import failure reason.
         """
 
-        raise ImportError('smolagents is not available - install "agent" extra to enable')
+        msg = 'smolagents is not available - install "agent" extra to enable'
+        if self._import_error:
+            msg += f". Underlying import error: {self._import_error}"
+
+        raise ImportError(msg)

--- a/test/python/test_placeholder_agent.py
+++ b/test/python/test_placeholder_agent.py
@@ -1,0 +1,52 @@
+"""
+Tests for placeholder Agent error messaging (#1161)
+"""
+
+import unittest
+
+
+class TestPlaceholderAgentErrorMessage(unittest.TestCase):
+    """
+    Test that placeholder.Agent surfaces the real import failure reason
+    instead of always blaming a missing smolagents install.
+    """
+
+    def testDefaultMessageUnchanged(self):
+        """
+        When no underlying import error is set, message is unchanged (backward compatible)
+        """
+        from txtai.agent.placeholder import Agent as PlaceholderAgent
+
+        PlaceholderAgent._import_error = None
+        try:
+            PlaceholderAgent()
+            self.fail("Expected ImportError")
+        except ImportError as e:
+            self.assertIn('smolagents is not available', str(e))
+            self.assertNotIn('Underlying import error', str(e))
+        finally:
+            PlaceholderAgent._import_error = None
+
+    def testUnderlyingImportErrorIncluded(self):
+        """
+        When an underlying import error is set (e.g. mcpadapt/mcp 2.0 incompatibility),
+        the real cause is included in the message
+        """
+        from txtai.agent.placeholder import Agent as PlaceholderAgent
+
+        PlaceholderAgent._import_error = (
+            "cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'"
+        )
+        try:
+            PlaceholderAgent()
+            self.fail("Expected ImportError")
+        except ImportError as e:
+            self.assertIn('smolagents is not available', str(e))
+            self.assertIn('Underlying import error', str(e))
+            self.assertIn('mcp.client.streamable_http', str(e))
+        finally:
+            PlaceholderAgent._import_error = None
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…#1161)

When agent dependencies fail to import (e.g. mcpadapt incompatible with mcp >= 2.0), the placeholder Agent always raised 'smolagents is not available', which was misleading when the agent extra was already installed.

Preserve the underlying ImportError and include it in the placeholder error message so users see the real cause.

- Save original ImportError in txtai/agent/__init__.py
- Include underlying error in placeholder Agent message
- Add tests for both default and enhanced error messages