### PR TITLE
fix(ann): honor quantize: false in the Faiss and SQLite backends

### DIFF
--- a/src/python/txtai/ann/dense/faiss.py
+++ b/src/python/txtai/ann/dense/faiss.py
@@ -142,7 +142,7 @@ class Faiss(ANN):
 
         # Derive quantization. Prefer backend-specific setting. Fallback to root-level parameter.
         quantize = self.setting("quantize", self.config.get("quantize"))
-        quantize = 8 if isinstance(quantize, bool) else quantize
+        quantize = 8 if quantize is True else quantize
 
         # Get storage setting
         storage = f"SQ{quantize}" if quantize else "Flat"

--- a/src/python/txtai/ann/dense/faiss.py
+++ b/src/python/txtai/ann/dense/faiss.py
@@ -142,7 +142,7 @@ class Faiss(ANN):
 
         # Derive quantization. Prefer backend-specific setting. Fallback to root-level parameter.
         quantize = self.setting("quantize", self.config.get("quantize"))
-        quantize = 8 if quantize is True else quantize
+        quantize = 8 if isinstance(quantize, bool) and quantize else quantize
 
         # Get storage setting
         storage = f"SQ{quantize}" if quantize else "Flat"

--- a/src/python/txtai/ann/dense/sqlite.py
+++ b/src/python/txtai/ann/dense/sqlite.py
@@ -32,7 +32,7 @@ class SQLite(ANN):
 
         # Quantization setting
         self.quantize = self.setting("quantize")
-        self.quantize = 8 if self.quantize is True else int(self.quantize) if self.quantize else None
+        self.quantize = 8 if isinstance(self.quantize, bool) and self.quantize else int(self.quantize) if self.quantize else None
 
     def load(self, path):
         self.path = path

--- a/src/python/txtai/ann/dense/sqlite.py
+++ b/src/python/txtai/ann/dense/sqlite.py
@@ -32,7 +32,7 @@ class SQLite(ANN):
 
         # Quantization setting
         self.quantize = self.setting("quantize")
-        self.quantize = 8 if isinstance(self.quantize, bool) else int(self.quantize) if self.quantize else None
+        self.quantize = 8 if self.quantize is True else int(self.quantize) if self.quantize else None
 
     def load(self, path):
         self.path = path

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -178,6 +178,16 @@ class TestDense(unittest.TestCase):
         self.assertLessEqual(expected, ann.backend.nlist)
         self.assertEqual(ann.nprobe(), expected)
 
+    def testFaissQuantizeDisabled(self):
+        """
+        Test that quantize: false disables Faiss storage quantization
+        """
+
+        for quantize, expected in [(False, "IDMap,Flat"), (True, "IDMap,SQ8")]:
+            with self.subTest(quantize=quantize):
+                ann = ANNFactory.create({"backend": "faiss", "dimensions": 4, "quantize": quantize})
+                self.assertEqual(ann.configure(100, 100), expected)
+
     def testGGML(self):
         """
         Test GGML backend
@@ -475,6 +485,16 @@ class TestDense(unittest.TestCase):
         model.save(new)
 
         self.assertEqual(model.count(), expected)
+
+    def testSQLiteQuantizeDisabled(self):
+        """
+        Test that quantize: false disables SQLite storage quantization
+        """
+
+        for quantize, expected in [(False, None), (True, 8), (1, 1)]:
+            with self.subTest(quantize=quantize):
+                ann = ANNFactory.create({"backend": "sqlite", "dimensions": 4, "sqlite": {"quantize": quantize}})
+                self.assertEqual(ann.quantize, expected)
 
     def testTorch(self):
         """


### PR DESCRIPTION
The ANN docs say `quantize: false` disables storage quantization ("true sets 8-bit precision, false disables, int sets specified precision"), but the Faiss backend does the opposite. `configure()` maps *any* bool to 8, so an explicit `quantize: false` builds `IDMap,SQ8` instead of `IDMap,Flat` and silently stores 8-bit vectors — the one thing the user asked it not to do. Changed the check to `quantize is True`, which is how the rest of the codebase reads this setting (`numpy.py`, `pgvector.py`, `vectors/base.py` and `transform.py` all exclude bools explicitly).

The same line exists in `sqlite.py`, with the same effect — `sqlite: {quantize: false}` resolved to 8 and turned on `vec_quantize_int8` — so I fixed it there too rather than leave half the backends disagreeing about the same config value.

Tests in `testann/testdense.py`. Both fail on current master (`'IDMap,SQ8' != 'IDMap,Flat'` and `8 != None`) and pass with the change; the rest of `testann.testdense` is unchanged (the errors there are the missing `ann` extra, same before and after).
