### PR TITLE
Fix quantize: false silently enabling Q8_0 quantization in the GGML backend

### DIFF
--- a/src/python/txtai/ann/dense/ggml.py
+++ b/src/python/txtai/ann/dense/ggml.py
@@ -519,7 +519,11 @@ class GGMLTensors:
 
         # Read tensor type
         tensortype = self.quantize
-        tensortype = "Q8_0" if isinstance(tensortype, bool) else f"Q{int(tensortype)}_0" if isinstance(tensortype, int) else tensortype
+        tensortype = (
+            "Q8_0"
+            if tensortype is True
+            else f"Q{int(tensortype)}_0" if isinstance(tensortype, int) and not isinstance(tensortype, bool) else tensortype
+        )
         tensortype = tensortype.upper() if tensortype else "F32"
 
         # Validate tensor type

--- a/src/python/txtai/ann/dense/ggml.py
+++ b/src/python/txtai/ann/dense/ggml.py
@@ -521,7 +521,7 @@ class GGMLTensors:
         tensortype = self.quantize
         tensortype = (
             "Q8_0"
-            if tensortype is True
+            if isinstance(tensortype, bool) and tensortype
             else f"Q{int(tensortype)}_0" if isinstance(tensortype, int) and not isinstance(tensortype, bool) else tensortype
         )
         tensortype = tensortype.upper() if tensortype else "F32"

--- a/test/python/testann/testdense.py
+++ b/test/python/testann/testdense.py
@@ -10,12 +10,14 @@ import unittest
 
 from unittest.mock import patch
 
+import ggml
 import numpy as np
 
 from sqlalchemy.dialects.postgresql import BIT
 from sqlalchemy.ext.compiler import compiles
 
 from txtai.ann import ANNFactory, ANN
+from txtai.ann.dense.ggml import GGMLTensors
 from txtai.serialize import SerializeFactory
 
 
@@ -212,6 +214,17 @@ class TestDense(unittest.TestCase):
         ann.save(index)
         ann.load(index)
         self.assertEqual(ann.count(), 99)
+
+    def testGGMLQuantizeDisabled(self):
+        """
+        Test that quantize: false disables GGML tensor quantization
+        """
+
+        data = np.random.rand(4, 256).astype(np.float32)
+        for quantize, expected in [(False, ggml.GGML_TYPE_F32), (True, ggml.GGML_TYPE_Q8_0), (4, ggml.GGML_TYPE_Q4_0)]:
+            with self.subTest(quantize=quantize):
+                tensors = GGMLTensors(False, 64, quantize)
+                self.assertEqual(tensors.tensortype(data), expected)
 
     def testGGMLEmpty(self):
         """


### PR DESCRIPTION
Fixes #1235.

`GGMLTensors.tensortype()` used `isinstance(quantize, bool)` to detect the default 8-bit quantization case, but that check is true for both `True` and `False`, so `quantize: false` took the same branch as `quantize: true` and produced `Q8_0` instead of falling through to `F32`.

The fix mirrors the `is True` check #1234 uses for the same shape in the Faiss and SQLite backends, combined with the `isinstance(x, int) and not isinstance(x, bool)` guard already used in `numpy.py`/`pgvector.py`/`faiss.py` to keep integer quantization levels (`quantize: 4`, `quantize: 8`, ...) working:

```python
tensortype = "Q8_0" if tensortype is True else f"Q{int(tensortype)}_0" if isinstance(tensortype, int) and not isinstance(tensortype, bool) else tensortype
```

`tensortype()` has exactly two call sites (`createtensors`, `mergetensors`), both of which only consume the returned GGML type constant to build a tensor, so nothing else depends on the old behavior.

Verification:
- `testGGMLQuantizeDisabled` (new): `quantize=False` now resolves to `F32`, `quantize=True` to `Q8_0`, `quantize=4` to `Q4_0`. Fails on master (`False` resolves to `Q8_0`), passes on this branch.
- Full `test.python.testann.testdense` suite (40 tests, all backends): passes.
- `black` and `pylint` (repo's own pre-commit config): clean.
- I did not test against an existing on-disk GGUF index, but `loadtensors()` reads the tensor type back from the file itself rather than calling `tensortype()`, so loading an index saved before this fix should be unaffected; only new writes with `quantize: false` change.
