### PR TITLE
fix(database): don't drop rows when sorting or grouping by a JSON field

### DIFF
--- a/src/python/txtai/database/rdbms.py
+++ b/src/python/txtai/database/rdbms.py
@@ -186,8 +186,9 @@ class RDBMS(Database):
         if indexids:
             select = f"{self.resolve('indexid')}, {self.resolve('score')}"
 
-        # Use JOIN when documents table is used to utilize indexes, default to LEFT JOIN
-        join = "JOIN" if any(x and self.jsonprefix() in x for x in [where, groupby, orderby]) else "LEFT JOIN"
+        # Use JOIN when a JSON field is filtered, since that filter already excludes rows without a
+        # documents row. GROUP BY/ORDER BY don't filter, so they keep the LEFT JOIN.
+        join = "JOIN" if where and self.jsonprefix() in where else "LEFT JOIN"
 
         # Build query text
         query = Statement.TABLE_CLAUSE % (select, join)

--- a/test/python/testdatabase/testrdbms.py
+++ b/test/python/testdatabase/testrdbms.py
@@ -654,6 +654,24 @@ class Common:
 
             self.assertEqual(result["text"], self.data[4])
 
+        def testSortMixed(self):
+            """
+            Test sorting and grouping by a JSON field with mixed text and document data
+            """
+
+            # Mix plain text, which has no documents table row, with a document that has a JSON field
+            embeddings = Embeddings({"keyword": True, "content": self.backend})
+            embeddings.index([(0, self.data[0], None), (1, {"text": self.data[1], "length": 5}, None)])
+
+            # Sorting must not change which rows come back
+            self.assertEqual(sorted(x["id"] for x in embeddings.search("select id from txtai order by length")), ["0", "1"])
+
+            # Grouping keeps a null group for rows missing the field
+            self.assertIn({"length": None, "total": 1}, embeddings.search("select length, count(*) as total from txtai group by length"))
+
+            # Filtering on the field still drops those rows
+            self.assertEqual([x["id"] for x in embeddings.search("select id from txtai where length is not null")], ["1"])
+
         def testSQL(self):
             """
             Test running a SQL query


### PR DESCRIPTION
`order by` on a JSON field drops rows instead of sorting them.

The JOIN promotion from 8e56946 (#1078) fires on `where`, `groupby` and `orderby`, but only `where` is safe. Plain text passed to `index()` never gets a `documents` row — `loaddocument` writes one only for dicts carrying extra fields — so an inner JOIN removes those sections from the result set entirely.

On a mixed index of one string and two documents with a `length` field:

```
select id from txtai                   ->  0, 1, 2
select id from txtai order by length   ->  1, 2
```

Sorting changed which rows came back. `group by` does the same thing from the other side: the null group vanishes, so aggregates quietly stop counting the text-only rows.

A `where` clause on a JSON field is genuinely different — comparing against NULL already excludes those rows, so the JOIN is a free index win there, and that's how #1078 described it ("when a JSON field filter is enabled"). Left that path alone; the new test asserts it still filters.

Test runs on both the SQLite and DuckDB backends and fails on master with `Lists differ: ['1'] != ['0', '1']`.
